### PR TITLE
Fix/add api root to buildspec

### DIFF
--- a/terraform/buildspec.yml.tml
+++ b/terraform/buildspec.yml.tml
@@ -13,7 +13,7 @@ phases:
     commands:
       - echo Running tests ...
       - docker run --name pg -d -p 5432:5432 postgres
-      - docker run --name test -d -e RAILS_ENV=test --link pg:pg ${image_repo_name}:test /bin/bash -c "tail -f /dev/null"
+      - docker run --name test -d -e RAILS_ENV=test -e API_ROOT=https://css.api --link pg:pg ${image_repo_name}:test /bin/bash -c "tail -f /dev/null"
       - docker exec test bundle install --with test --retry 3 --jobs 20
       - docker exec test /bin/bash -c "export DATABASE_URL='postgres://postgres@pg:5432/test?template=template0&pool=5&encoding=unicode' && rake db:create"
       - docker exec test /bin/bash -c "export DATABASE_URL='postgres://postgres@pg:5432/test?template=template0&pool=5&encoding=unicode' && rake db:setup"

--- a/terraform/buildspec.yml.tml
+++ b/terraform/buildspec.yml.tml
@@ -13,7 +13,7 @@ phases:
     commands:
       - echo Running tests ...
       - docker run --name pg -d -p 5432:5432 postgres
-      - docker run --name test -d -e RAILS_ENV=test -e API_ROOT=https://css.api --link pg:pg ${image_repo_name}:test /bin/bash -c "tail -f /dev/null"
+      - docker run --name test -d -e RAILS_ENV=test -e API_ROOT=https://css.api/ --link pg:pg ${image_repo_name}:test /bin/bash -c "tail -f /dev/null"
       - docker exec test bundle install --with test --retry 3 --jobs 20
       - docker exec test /bin/bash -c "export DATABASE_URL='postgres://postgres@pg:5432/test?template=template0&pool=5&encoding=unicode' && rake db:create"
       - docker exec test /bin/bash -c "export DATABASE_URL='postgres://postgres@pg:5432/test?template=template0&pool=5&encoding=unicode' && rake db:setup"

--- a/terraform/buildspec.yml.tml
+++ b/terraform/buildspec.yml.tml
@@ -13,7 +13,7 @@ phases:
     commands:
       - echo Running tests ...
       - docker run --name pg -d -p 5432:5432 postgres
-      - docker run --name test -d -e RAILS_ENV=test -e API_ROOT=https://css.api/ --link pg:pg ${image_repo_name}:test /bin/bash -c "tail -f /dev/null"
+      - docker run --name test -d -e RAILS_ENV=test -e API_ROOT=https://ccs.api/ --link pg:pg ${image_repo_name}:test /bin/bash -c "tail -f /dev/null"
       - docker exec test bundle install --with test --retry 3 --jobs 20
       - docker exec test /bin/bash -c "export DATABASE_URL='postgres://postgres@pg:5432/test?template=template0&pool=5&encoding=unicode' && rake db:create"
       - docker exec test /bin/bash -c "export DATABASE_URL='postgres://postgres@pg:5432/test?template=template0&pool=5&encoding=unicode' && rake db:setup"


### PR DESCRIPTION
* the tests environment needs this set to 'https://ccs.api/ to run