### PR TITLE
(123) Do Levy Calculation (Frontend changes)

### DIFF
--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -18,11 +18,31 @@ class ReviewsController < ApplicationController
   end
 
   def processing
+    case params[:state]
+    when 'ingest'
+      @polling_url = task_submission_review_ingest_status_polling_path
+      ingest_processing
+    when 'calculate'
+      submission.calculate
+      @polling_url = task_submission_review_calculate_status_polling_path
+      calculate_processing
+    end
+  end
+
+  def ingest_processing
     redirect_to new_task_submission_review_path if ingest_entries_completed?
+  end
+
+  def calculate_processing
+    redirect_to new_task_submission_review_path if levy_calculation_completed?
   end
 
   def ingest_status_polling
     render json: { complete: ingest_entries_completed? }
+  end
+
+  def calculate_status_polling
+    render json: { complete: levy_calculation_completed? }
   end
 
   private
@@ -49,7 +69,11 @@ class ReviewsController < ApplicationController
     expected_number_of_rows == submission_entries.count
   end
 
+  def levy_calculation_completed?
+    submission.status == 'complete'
+  end
+
   def validator
-    @validator ||= Validator.new(submission_entries: submission_entries)
+    @validator ||= Validator.new(submission: submission)
   end
 end

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -25,7 +25,7 @@ class SubmissionsController < ApplicationController
     )
 
     redirect_to(
-      task_submission_review_processing_path(task_id: task.id, submission_id: submission.id),
+      task_submission_review_processing_path(task_id: task.id, submission_id: submission.id, state: 'ingest'),
       flash: { notice: "#{blob.filename} file upload successful!" }
     )
   end

--- a/app/models/api/submission.rb
+++ b/app/models/api/submission.rb
@@ -2,5 +2,8 @@ module API
   class Submission < Base
     has_many :entries, class_name: 'SubmissionEntry'
     has_many :files, class_name: 'SubmissionFile'
+
+    # GET /submissions/:id/calculate
+    custom_endpoint :calculate, on: :member, request_method: :get
   end
 end

--- a/app/models/api/submission.rb
+++ b/app/models/api/submission.rb
@@ -4,6 +4,6 @@ module API
     has_many :files, class_name: 'SubmissionFile'
 
     # GET /submissions/:id/calculate
-    custom_endpoint :calculate, on: :member, request_method: :get
+    custom_endpoint :calculate, on: :member, request_method: :post
   end
 end

--- a/app/views/reviews/new.html.haml
+++ b/app/views/reviews/new.html.haml
@@ -24,20 +24,33 @@
       %span.data-item.bold-xsmall Invoices
   .column-one-third
 
-- if @validator.errors
-  %ul
-  - @validator.errors.each do |error|
-    %li.u_error= error['message']
+- if @validator.status == 'levy_completed'
+  .grid-row
+    %p.font-large
+      Your Levy Calculation is:
+      %strong.bold
+        £
+        = @submission.levy
 
-  = link_to 'submit another file', new_task_submission_path(@task.id)
-  and start again
-- else
-  %p
-    If this looks wrong, you can
+.grid-row
+  - if @validator.errors
+    %ul
+    - @validator.errors.each do |error|
+      %li.u_error= error['message']
+
     = link_to 'submit another file', new_task_submission_path(@task.id)
     and start again
+  - else
+    %p
+      If this looks wrong, you can
+      = link_to 'submit another file', new_task_submission_path(@task.id)
+      and start again
 
-- if @validator.status == 'validated'
+- case @validator.status
+- when 'validated'
+  .form-group
+    = link_to 'Continue', task_submission_review_processing_path(task_id: @task.id, submission_id: @submission.id, state: 'calculate'), class: 'button'
+- when 'levy_completed'
   = form_tag(task_submission_review_path(submission_id: params[:submission_id])) do
     .form-group
       = submit_tag 'Continue', class: 'button'

--- a/app/views/reviews/new.html.haml
+++ b/app/views/reviews/new.html.haml
@@ -53,4 +53,4 @@
 - when 'levy_completed'
   = form_tag(task_submission_review_path(submission_id: params[:submission_id])) do
     .form-group
-      = submit_tag 'Continue', class: 'button'
+      = submit_tag 'Confirm', class: 'button'

--- a/app/views/reviews/processing.html.haml
+++ b/app/views/reviews/processing.html.haml
@@ -4,7 +4,7 @@
 
 :javascript
 
-  var polling_url = "#{task_submission_review_ingest_status_polling_path}";
+  var polling_url = "#{@polling_url}";
   var review_url = "#{new_task_submission_review_path}";
 
   function checkStatus() {

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,7 @@ Rails.application.routes.draw do
     resources :submissions, only: %i[new create] do
       resource :review, only: %i[new create]
       get '/review/ingest_status_polling/', to: 'reviews#ingest_status_polling'
+      get '/review/calculate_status_polling/', to: 'reviews#calculate_status_polling'
       get '/review/processing/', to: 'reviews#processing'
     end
   end

--- a/lib/validator.rb
+++ b/lib/validator.rb
@@ -1,10 +1,13 @@
 class Validator
-  def initialize(submission_entries:)
-    @submission_entries = submission_entries
+  def initialize(submission:)
+    @submission = submission
+    @submission_entries = submission.entries
   end
 
   def status
-    if validated?
+    if levy_completed?
+      'levy_completed'
+    elsif validated?
       'validated'
     elsif errored?
       'errored'
@@ -29,5 +32,13 @@ class Validator
 
   def errored?
     @submission_entries.map(&:status).any? { |status| status == 'errored' }
+  end
+
+  def submission_completed?
+    @submission.status == 'complete'
+  end
+
+  def levy_completed?
+    validated? && submission_completed?
   end
 end

--- a/spec/features/users_can_review_completed_spreadsheet_spec.rb
+++ b/spec/features/users_can_review_completed_spreadsheet_spec.rb
@@ -52,7 +52,8 @@ RSpec.feature 'User reviews completed spreadsheet' do
           id: '9a5ef62c-0781-4f80-8850-5793652b6b40',
           type: 'submissions',
           attributes: {
-            task_id: '2d98639e-5260-411f-a5ee-61847a2e067c'
+            task_id: '2d98639e-5260-411f-a5ee-61847a2e067c',
+            status: 'pending'
           }
         }
       }
@@ -66,80 +67,6 @@ RSpec.feature 'User reviews completed spreadsheet' do
             rows: 3
           }
         }
-      }
-
-      submission_with_files_and_entries = {
-        data: {
-          id: '9a5ef62c-0781-4f80-8850-5793652b6b40',
-          type: 'submissions',
-          attributes: {
-            framework_id: 'f87717d4-874a-43d9-b99f-c8cf2897b526',
-            supplier_id: 'cd40ead8-67b5-4918-abf0-ab8937cd04ff'
-          },
-          relationships: {
-            entries: {
-              data: [
-                {
-                  type: 'submission_entries',
-                  id: 'f87717d4-874a-43d9-b99f-c8cf2897b526'
-                },
-                {
-                  type: 'submission_entries',
-                  id: '1eb3b8ee-0ac6-4b8f-86a5-6886b33c63ff'
-                },
-                {
-                  type: 'submission_entries',
-                  id: '32423310-e3b6-4e2f-b022-a4854d8085ab'
-                }
-              ]
-            },
-            files: {
-              data: [
-                {
-                  type: 'submission_files',
-                  id: '41bea03d-fc99-45fb-9efc-2787530409f8'
-                }
-              ]
-            }
-          }
-        },
-        included: [
-          {
-            id: 'f87717d4-874a-43d9-b99f-c8cf2897b526',
-            type: 'submission_entries',
-            attributes: {
-              source: { row: 42, sheet: 'InvoicesRaised' },
-              data: { test: 'test' },
-              status: 'validated'
-            }
-          },
-          {
-            id: '32423310-e3b6-4e2f-b022-a4854d8085ab',
-            type: 'submission_entries',
-            attributes: {
-              source: { row: 40, sheet: 'Invoices Raised' },
-              data: { test: 'test' },
-              status: 'validated'
-            }
-          },
-          {
-            id: '1eb3b8ee-0ac6-4b8f-86a5-6886b33c63ff',
-            type: 'submission_entries',
-            attributes: {
-              source: { row: 1, sheet: ' Orders  Received ' },
-              data: { test: 'test' },
-              status: 'validated'
-            }
-          },
-          {
-            id: '41bea03d-fc99-45fb-9efc-2787530409f8',
-            type: 'submission_files',
-            attributes: {
-              submission_id: '9a5ef62c-0781-4f80-8850-5793652b6b40',
-              rows: 3
-            }
-          }
-        ]
       }
 
       stub_request(:get, 'https://ccs.api/v1/tasks')
@@ -170,7 +97,7 @@ RSpec.feature 'User reviews completed spreadsheet' do
       stub_request(:get, 'https://ccs.api/v1/submissions/9a5ef62c-0781-4f80-8850-5793652b6b40?include=files,entries')
         .to_return(
           headers: { 'Content-Type': 'application/vnd.api+json; charset=utf-8' },
-          body: submission_with_files_and_entries.to_json
+          body: Rails.root.join('spec', 'fixtures', 'submission.json')
         )
 
       task_params = {
@@ -187,7 +114,7 @@ RSpec.feature 'User reviews completed spreadsheet' do
         .with(body: task_params.to_json)
     end
 
-    scenario 'successfully review and complete the submission process' do
+    scenario 'successfully review contents in the uploaded file' do
       mock_sso_with(email: 'email@example.com')
 
       visit '/'

--- a/spec/features/users_can_trigger_and_view_levy_calculation_spec.rb
+++ b/spec/features/users_can_trigger_and_view_levy_calculation_spec.rb
@@ -1,0 +1,166 @@
+require 'rails_helper'
+
+RSpec.feature 'User triggers and views levy calculation' do
+  feature 'Signed-in user can review an uploaded completed spreadsheet' do
+    before(:each) do
+      tasks = {
+        data: [
+          id: '2d98639e-5260-411f-a5ee-61847a2e067c',
+          type: 'tasks',
+          attributes: {
+            description: 'test task',
+            due_on: '2030-01-01',
+            framework_id: 'f87717d4-874a-43d9-b99f-c8cf2897b526',
+            supplier_id: 'cd40ead8-67b5-4918-abf0-ab8937cd04ff'
+          }
+        ]
+      }
+
+      task_with_framework = {
+        data: {
+          id: '2d98639e-5260-411f-a5ee-61847a2e067c',
+          type: 'tasks',
+          attributes: {
+            description: 'test task',
+            due_on: '2030-01-01',
+            framework_id: 'f87717d4-874a-43d9-b99f-c8cf2897b526',
+            supplier_id: 'cd40ead8-67b5-4918-abf0-ab8937cd04ff'
+          },
+          relationships: {
+            framework: {
+              data: {
+                type: 'frameworks',
+                id: 'f87717d4-874a-43d9-b99f-c8cf2897b526'
+              }
+            }
+          }
+        },
+        included: [
+          {
+            id: 'f87717d4-874a-43d9-b99f-c8cf2897b526',
+            type: 'frameworks',
+            attributes: {
+              short_name: 'CBOARD5',
+              name: 'Cheese Board 5'
+            }
+          }
+        ]
+      }
+
+      task_submission = {
+        data: {
+          id: '9a5ef62c-0781-4f80-8850-5793652b6b40',
+          type: 'submissions',
+          attributes: {
+            task_id: '2d98639e-5260-411f-a5ee-61847a2e067c'
+          }
+        }
+      }
+
+      submission_file = {
+        data: {
+          id: '41bea03d-fc99-45fb-9efc-2787530409f8',
+          type: 'submission_files',
+          attributes: {
+            submission_id: '9a5ef62c-0781-4f80-8850-5793652b6b40',
+            rows: 3
+          }
+        }
+      }
+
+      stub_request(:get, 'https://ccs.api/v1/tasks')
+        .with(query: hash_including({}))
+        .to_return(
+          headers: { 'Content-Type': 'application/vnd.api+json; charset=utf-8' },
+          body: tasks.to_json
+        )
+
+      stub_request(:get, 'https://ccs.api/v1/tasks/2d98639e-5260-411f-a5ee-61847a2e067c?include=framework')
+        .to_return(
+          headers: { 'Content-Type': 'application/vnd.api+json; charset=utf-8' },
+          body: task_with_framework.to_json
+        )
+
+      stub_request(:post, 'https://ccs.api/v1/submissions')
+        .to_return(
+          headers: { 'Content-Type': 'application/vnd.api+json; charset=utf-8' },
+          body: task_submission.to_json
+        )
+
+      stub_request(:get, 'https://ccs.api/v1/submissions/9a5ef62c-0781-4f80-8850-5793652b6b40/files')
+        .to_return(
+          headers: { 'Content-Type': 'application/vnd.api+json; charset=utf-8' },
+          body: submission_file.to_json
+        )
+
+      task_params = {
+        data: {
+          id: '2d98639e-5260-411f-a5ee-61847a2e067c',
+          type: 'tasks',
+          attributes: {
+            status: 'in_progress'
+          }
+        }
+      }
+
+      stub_request(:patch, 'https://ccs.api/v1/tasks/2d98639e-5260-411f-a5ee-61847a2e067c')
+        .with(body: task_params.to_json)
+
+      stub_request(:get, 'https://ccs.api/v1/submissions/9a5ef62c-0781-4f80-8850-5793652b6b40/calculate')
+        .to_return(
+          headers: { 'Content-Type': 'application/vnd.api+json; charset=utf-8' },
+          status: 200
+        )
+    end
+
+    scenario 'successfully triggers levy calculation' do
+      mock_submission_without_levy
+
+      login_and_upload_file
+
+      expect(page).to have_content('Review your information')
+
+      click_link 'Continue'
+      expect(page).to have_content('processing...')
+    end
+
+    scenario 'successfully views levy calculation' do
+      mock_submission_with_levy_completed
+
+      login_and_upload_file
+
+      expect(page).to have_content('Your Levy Calculation is: £ 4500')
+    end
+  end
+
+  def login_and_upload_file
+    mock_sso_with(email: 'email@example.com')
+
+    visit '/'
+    click_on 'Sign in'
+
+    visit '/tasks'
+    click_on 'Upload submission'
+
+    expect(page).to have_content('Upload submission for CBOARD5')
+
+    attach_file 'upload', Rails.root.join('spec', 'fixtures', 'uploads', 'empty.xlsx')
+    click_button 'Upload'
+  end
+
+  def mock_submission_without_levy
+    stub_request(:get, 'https://ccs.api/v1/submissions/9a5ef62c-0781-4f80-8850-5793652b6b40?include=files,entries')
+      .to_return(
+        headers: { 'Content-Type': 'application/vnd.api+json; charset=utf-8' },
+        body: Rails.root.join('spec', 'fixtures', 'submission.json')
+      )
+  end
+
+  def mock_submission_with_levy_completed
+    stub_request(:get, 'https://ccs.api/v1/submissions/9a5ef62c-0781-4f80-8850-5793652b6b40?include=files,entries')
+      .to_return(
+        headers: { 'Content-Type': 'application/vnd.api+json; charset=utf-8' },
+        body: Rails.root.join('spec', 'fixtures', 'submission_with_levy.json')
+      )
+  end
+end

--- a/spec/features/users_can_trigger_and_view_levy_calculation_spec.rb
+++ b/spec/features/users_can_trigger_and_view_levy_calculation_spec.rb
@@ -106,10 +106,10 @@ RSpec.feature 'User triggers and views levy calculation' do
       stub_request(:patch, 'https://ccs.api/v1/tasks/2d98639e-5260-411f-a5ee-61847a2e067c')
         .with(body: task_params.to_json)
 
-      stub_request(:get, 'https://ccs.api/v1/submissions/9a5ef62c-0781-4f80-8850-5793652b6b40/calculate')
+      stub_request(:post, 'https://ccs.api/v1/submissions/9a5ef62c-0781-4f80-8850-5793652b6b40/calculate')
         .to_return(
           headers: { 'Content-Type': 'application/vnd.api+json; charset=utf-8' },
-          status: 200
+          status: 204
         )
     end
 

--- a/spec/fixtures/submission.json
+++ b/spec/fixtures/submission.json
@@ -1,0 +1,74 @@
+{
+  "data": {
+    "id": "9a5ef62c-0781-4f80-8850-5793652b6b40",
+    "type": "submissions",
+    "attributes": {
+      "framework_id": "f87717d4-874a-43d9-b99f-c8cf2897b526",
+      "supplier_id": "cd40ead8-67b5-4918-abf0-ab8937cd04ff",
+      "status": "in_progress"
+    },
+    "relationships": {
+      "entries": {
+        "data": [
+          {
+            "type": "submission_entries",
+            "id": "f87717d4-874a-43d9-b99f-c8cf2897b526"
+          },
+          {
+            "type": "submission_entries",
+            "id": "1eb3b8ee-0ac6-4b8f-86a5-6886b33c63ff"
+          },
+          {
+            "type": "submission_entries",
+            "id": "32423310-e3b6-4e2f-b022-a4854d8085ab"
+          }
+        ]
+      },
+      "files": {
+        "data": [
+          {
+            "type": "submission_files",
+            "id": "41bea03d-fc99-45fb-9efc-2787530409f8"
+          }
+        ]
+      }
+    }
+  },
+  "included": [
+    {
+      "id": "f87717d4-874a-43d9-b99f-c8cf2897b526",
+      "type": "submission_entries",
+      "attributes": {
+        "source": { "row": 42, "sheet": "InvoicesRaised" },
+        "data": { "test": "test" },
+        "status": "validated"
+      }
+    },
+    {
+      "id": "32423310-e3b6-4e2f-b022-a4854d8085ab",
+      "type": "submission_entries",
+      "attributes": {
+        "source": { "row": 40, "sheet": "Invoices Raised" },
+        "data": { "test": "test" },
+        "status": "validated"
+      }
+    },
+    {
+      "id": "1eb3b8ee-0ac6-4b8f-86a5-6886b33c63ff",
+      "type": "submission_entries",
+      "attributes": {
+        "source": { "row": 1, "sheet": " Orders  Received " },
+        "data": { "test": "test" },
+        "status": "validated"
+      }
+    },
+    {
+      "id": "41bea03d-fc99-45fb-9efc-2787530409f8",
+      "type": "submission_files",
+      "attributes": {
+        "submission_id": "9a5ef62c-0781-4f80-8850-5793652b6b40",
+        "rows": 3
+      }
+    }
+  ]
+}

--- a/spec/fixtures/submission_with_levy.json
+++ b/spec/fixtures/submission_with_levy.json
@@ -1,0 +1,75 @@
+{
+  "data": {
+    "id": "9a5ef62c-0781-4f80-8850-5793652b6b40",
+    "type": "submissions",
+    "attributes": {
+      "framework_id": "f87717d4-874a-43d9-b99f-c8cf2897b526",
+      "supplier_id": "cd40ead8-67b5-4918-abf0-ab8937cd04ff",
+      "status": "complete",
+      "levy": 4500
+    },
+    "relationships": {
+      "entries": {
+        "data": [
+          {
+            "type": "submission_entries",
+            "id": "f87717d4-874a-43d9-b99f-c8cf2897b526"
+          },
+          {
+            "type": "submission_entries",
+            "id": "1eb3b8ee-0ac6-4b8f-86a5-6886b33c63ff"
+          },
+          {
+            "type": "submission_entries",
+            "id": "32423310-e3b6-4e2f-b022-a4854d8085ab"
+          }
+        ]
+      },
+      "files": {
+        "data": [
+          {
+            "type": "submission_files",
+            "id": "41bea03d-fc99-45fb-9efc-2787530409f8"
+          }
+        ]
+      }
+    }
+  },
+  "included": [
+    {
+      "id": "f87717d4-874a-43d9-b99f-c8cf2897b526",
+      "type": "submission_entries",
+      "attributes": {
+        "source": { "row": 42, "sheet": "InvoicesRaised" },
+        "data": { "test": "test" },
+        "status": "validated"
+      }
+    },
+    {
+      "id": "32423310-e3b6-4e2f-b022-a4854d8085ab",
+      "type": "submission_entries",
+      "attributes": {
+        "source": { "row": 40, "sheet": "Invoices Raised" },
+        "data": { "test": "test" },
+        "status": "validated"
+      }
+    },
+    {
+      "id": "1eb3b8ee-0ac6-4b8f-86a5-6886b33c63ff",
+      "type": "submission_entries",
+      "attributes": {
+        "source": { "row": 1, "sheet": " Orders  Received " },
+        "data": { "test": "test" },
+        "status": "validated"
+      }
+    },
+    {
+      "id": "41bea03d-fc99-45fb-9efc-2787530409f8",
+      "type": "submission_files",
+      "attributes": {
+        "submission_id": "9a5ef62c-0781-4f80-8850-5793652b6b40",
+        "rows": 3
+      }
+    }
+  ]
+}


### PR DESCRIPTION
# Description
This PR:
- Triggers and polls API for levy calculation when user clicks continue on the review page after validation is successful
- Displays levy calculation to the user

Instead of creating new pages and controllers for the levy calculation polling and display, the `ReviewsController` and `/views/reviews` pages were used for polling both the ingest and the calculate APIs. A `state` query param was added to the `review_processing_path` which will be checked to identify the appropriate url and method to call at the `ReviewsController#processing` action.

# Status
Ready for review