### PR TITLE
(148) Custom UI with Auth0 without Javascript

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -16,6 +16,48 @@ class SessionsController < ApplicationController
     redirect_to '/', notice: 'You are now signed out'
   end
 
+  def create_from_api
+    if params[:commit] == 'Log in'
+      sign_in(params)
+    elsif params[:commit] == 'Sign up'
+      register(params)
+    end
+  end
+
+  def register(params)
+    auth = Authenticator.new.sign_up(params: params)
+    if auth.code == 200
+      user = User.from_auth0(auth)
+      session[:user_id] = user.id
+
+      Auditor.new.user_signed_in(user_id: user.id)
+
+      redirect_to '/tasks', notice: 'You are now signed in'
+    else
+      # handle error
+      error = JSON.parse(auth.body)
+      flash.now[:alert] = error['message'].to_s + error['policy'].to_s
+      render :new
+    end
+  end
+
+  def sign_in(params)
+    auth = Authenticator.new.authorize_with_password(params: params)
+    if auth.code == 200
+      user = User.from_auth0(auth)
+      session[:user_id] = user.id
+
+      Auditor.new.user_signed_in(user_id: user.id)
+
+      redirect_to '/tasks', notice: 'You are now signed in'
+    else
+      # handle error
+      error = JSON.parse(auth.body)
+      flash.now[:alert] = error['message'].to_s + error['policy'].to_s
+      render :new
+    end
+  end
+
   protected
 
   def auth_hash

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,4 +5,11 @@ class User < ApplicationRecord
       u.auth_hash = auth
     end
   end
+
+  def self.from_auth0(auth)
+    User.find_or_create_by(uid: auth._id) do |u|
+      u.email = auth.email
+      u.auth_hash = auth
+    end
+  end
 end

--- a/app/views/sessions/new.html.haml
+++ b/app/views/sessions/new.html.haml
@@ -1,0 +1,13 @@
+%h3 Welcome, Please Log In
+.form-group
+  = form_tag(sessions_path) do
+    .form-group
+      = text_field_tag 'email', nil, placeholder: 'Email', required: true
+    .form-group
+      = password_field_tag 'password', nil, placeholder: 'Password', required: true
+    .form-group
+      = submit_tag 'Log in', class: 'button'
+    .form-group
+      = submit_tag 'Sign up', class: ''
+    .form-group
+      = submit_tag 'Log In with Google', class: ''

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,5 +12,7 @@ Rails.application.routes.draw do
 
   get '/auth/:provider/callback', to: 'sessions#create'
   get '/sign_out', to: 'sessions#destroy', as: :sign_out
+  get '/sign_in', to: 'sessions#new', as: :sign_in
+  post '/sessions', to: 'sessions#create_from_api'
   get '/style_guide', to: 'styleguide#index'
 end

--- a/lib/authenticator.rb
+++ b/lib/authenticator.rb
@@ -1,0 +1,45 @@
+class Authenticator
+  include HTTParty
+  base_uri ENV['AUTH0_DOMAIN']
+
+  def get_user_info(token:)
+    response = self.class.get('/userinfo', headers: { Authorization: "Bearer #{token}" })
+    puts response.body
+    response
+  end
+
+  def authorize_with_password(params:)
+    # On the Dashboard, visit https://manage.auth0.com/#/tenant and set
+    # Default Directory: 'Username-Password-Authentication',
+    # Default Audience: 'https://esther-test.eu.auth0.com/api/v2/'
+    # And in Application Settings, Enable Password as Grant Types
+    body = {
+      client_id: ENV['AUTH0_CLIENT_ID'],
+      client_secret: ENV['AUTH0_CLIENT_SECRET'],
+      username: params[:email],
+      password: params[:password],
+      grant_type: 'password',
+      scope: 'openid'
+    }
+
+    response = self.class.post('/oauth/token', body: body)
+    response_body = JSON.parse(response.body)
+
+    token = response_body['access_token']
+    puts token
+    get_user_info(token: token)
+  end
+
+  def sign_up(params:)
+    body = {
+      email: params[:email],
+      password: params[:password],
+      connection: 'Username-Password-Authentication',
+      client_id: ENV['AUTH0_CLIENT_ID']
+    }
+
+    response = self.class.post('/dbconnections/signup', body: body)
+    puts response.body
+    response
+  end
+end


### PR DESCRIPTION
# Description
A first draft attempt at Login and Sign Up using Custom UI with Auth0 APIs without Javascript.

The goal is: To login and sign up via Auth0 using GOV.uk customised pages without using/redirecting to Auth0's hosted Login UI pages

Test page is at: `/sign_in`

## Sign In:
- Authenticate to obtain an access_token using the password grant_type
- Use the token to retrieve the user profile
- Create a user record using the retrieved user profile on the app's user model.

Docs:
- Resource Owner Password: https://auth0.com/docs/api/authentication#resource-owner-password
This requires some tweaking of settings on the Auth0 dashboard to enable this as it's not available by default.

- Retrieve User Profile:  https://auth0.com/docs/api/authentication#get-user-info

## Sign Up: 
- Make API call to the Auth0 `dbconnections/signup` API endpoint which returns some user data, 
- then create a user record using the retrieved user profile on the app's user model.

Docs:
Custom UI Sign Up: https://auth0.com/docs/libraries/custom-signup

## TODO:
- Study Auth0's API responses and error messages so that we can handle errors and responses from the API more elegantly
- I made use of the same view for both sign in and sign up as a test case while checking the `params[:commit]` to determine which method to call. This should be refactored to separate the views
