### PR TITLE
(195) Update confirmation page

### DIFF
--- a/app/views/reviews/create.html.haml
+++ b/app/views/reviews/create.html.haml
@@ -1,25 +1,14 @@
 .grid-row
   .column-two-thirds
     .govuk-box-highlight
-      %h1.heading-xlarge Return completed
-      %p.font-large
-        Your reference number is
-        %br
-        %strong.bold 124345
+      %h1.heading-xlarge Submission completed
 .grid-row
   .column-two-thirds
     %p= t('.message.para_1')
-    %p
-      We estimate that this will be
-      %strong.bold
-        £
-        = @submission.levy
-
     %p= t('.message.para_2')
-    %p= t('.message.para_3')
 
 .form-group
   = link_to t('uploads.review.back'), tasks_path, class: 'button'
 
 .form-group
-= link_to 'Log out', sign_out_path, class: 'button'
+  = link_to 'Log out', sign_out_path, class: 'button'

--- a/config/locales/en/reviews.yml
+++ b/config/locales/en/reviews.yml
@@ -2,7 +2,5 @@ en:
   reviews:
     create:
       message:
-        para_1: You’ll receive an invoice from Crown Commercial Service within a week, based on the management information you’ve provided.
-        para_2: We estimate that this will be £xxxx
-        para_3: If you’ve made a mistake or need to amend the management information you’ve supplied, [contact the service desk] for help.
-        para_4: Next month’s management information is due on [date]. We’ll send you a reminder for this and any other outstanding tasks on [date]. You can [set an earlier reminder] if you need to.
+        para_1: If you’ve made a mistake or need to amend the management information you’ve supplied, [contact the service desk] for help.
+        para_2: Next month’s management information is due on [date]. We’ll send you a reminder for this and any other outstanding tasks on [date]. You can [set an earlier reminder] if you need to.


### PR DESCRIPTION
Change the copy and remove the reference number.

We do not want to confuse a user with incorrect information or data we
cannot provide in the MVP.