### PR TITLE
Increase module length limit in Rubocop config

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -57,6 +57,10 @@ Metrics/MethodLength:
     Max: 50
     Exclude:
 
+Metrics/ModuleLength:
+    Description: 'Avoid modules longer than 250 lines of code.'
+    Max: 250
+
 Metrics/AbcSize:
     Max: 25 # TODO: Restore to '20'
     Exclude:


### PR DESCRIPTION
The default is 100, which is a bit agressive for the stage we're at and
the speed at which we need to go.