### PR TITLE
(185) tools page

### DIFF
--- a/app/controllers/tools_controller.rb
+++ b/app/controllers/tools_controller.rb
@@ -1,0 +1,3 @@
+class ToolsController < ApplicationController
+  def index; end
+end

--- a/app/views/shared/_top_navigation.html.haml
+++ b/app/views/shared/_top_navigation.html.haml
@@ -7,6 +7,8 @@
       %li
         = link_to 'Tasks', tasks_path
       %li
+        = link_to 'Tools', '/tools'
+      %li
         = link_to "Sign out #{current_user.email}", '/sign_out'
     - else
       %li

--- a/app/views/tools/index.html.haml
+++ b/app/views/tools/index.html.haml
@@ -1,0 +1,32 @@
+.grid-row
+  .column-two-thirds
+    %h1.heading-xlarge
+      Tools
+
+    %p
+      These tools will help you complete your submission.
+
+    %h2.heading-medium
+      Unique Reference Number (URN) Lookup
+
+    %p
+      You will be asked to supply a unique reference number for your customers
+      in your template files, if you do not know your customer URN you can look
+        it up in this Excel file.
+
+    = link_to 'Download CCS URN List (July 2018).xls',
+      '/urn/CCS URN List (July 2018).xls'
+    (12.4MB)
+
+    %h3.heading-small
+      Finding a URN
+    %p
+      Open this file in Microsoft Excel and use the find functionality to locate
+      your customer, we recomend using the customer postcode as it is the most
+      acurate
+
+    %h3.heading-small
+      Missing URN
+    %p
+      If you have a customer without a URN you will need to contact the support
+      team to have one created for you.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,4 +13,5 @@ Rails.application.routes.draw do
   get '/auth/:provider/callback', to: 'sessions#create'
   get '/sign_out', to: 'sessions#destroy', as: :sign_out
   get '/style_guide', to: 'styleguide#index'
+  get '/tools', to: 'tools#index'
 end

--- a/spec/features/users_can_access_a_page_and_download_a_urn_list.rb
+++ b/spec/features/users_can_access_a_page_and_download_a_urn_list.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+RSpec.feature 'User can access a page' do
+  scenario 'with instructions and a link to the URN list.' do
+    mock_sso_with(email: 'email@example.com')
+    mock_tasks_endpoint!
+    mock_task_with_framework_endpoint!
+
+    visit '/'
+    click_link 'sign-in'
+
+    visit '/tools'
+    expect(page).to have_link('Download CCS URN List (July 2018).xls', href: '/urn/CCS URN List (July 2018).xls')
+  end
+end


### PR DESCRIPTION
Add a tools page with instructions and a link to the URN list.

This is a temporary measure for August so that beta users can lookup URNs.
The file name includes the month as I would like users to be able to
identify the latest copy of the file at a glance, If it turns out we
need to update this file more than once a month we'll need to change
approach, but this is my happy place for now.

I've added a route, controller, view, feature spec and the file.