### PR TITLE
(233) User can mark a submission as completed

### DIFF
--- a/app/controllers/submission_completion_controller.rb
+++ b/app/controllers/submission_completion_controller.rb
@@ -1,0 +1,9 @@
+class SubmissionCompletionController < ApplicationController
+  def create
+    submission = API::Submission.includes(:task).find(params[:submission_id]).first
+    submission.complete
+
+    redirect_to task_submission_path(task_id: submission.task.id, id: submission.id),
+                notice: "You have completed task '#{submission.task.description}'."
+  end
+end

--- a/app/models/api/submission.rb
+++ b/app/models/api/submission.rb
@@ -2,9 +2,13 @@ module API
   class Submission < Base
     has_many :entries, class_name: 'SubmissionEntry'
     has_many :files, class_name: 'SubmissionFile'
+    has_one :task
 
     # GET /submissions/:id/calculate
     custom_endpoint :calculate, on: :member, request_method: :post
+
+    # POST /submissions/:id/complete
+    custom_endpoint :complete, on: :member, request_method: :post
 
     def orders_count
       entries.count { |entry| entry.source['sheet'].match?(/order/i) }

--- a/app/views/submissions/in_review.html.haml
+++ b/app/views/submissions/in_review.html.haml
@@ -62,7 +62,7 @@
     %p
       This submission is not completed until you have clicked this button:
 
-  = form_tag(task_submission_review_path(task_id: @task.id, submission_id: @submission.id)) do
+  = form_tag(task_submission_complete_path(task_id: @task.id, submission_id: @submission.id), method: :post) do
     .form-group
       = submit_tag 'Complete submission', class: 'button'
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,8 @@ Rails.application.routes.draw do
 
   resources :tasks, only: %i[index] do
     resources :submissions, only: %i[new create show] do
+      resource :complete, only: :create, controller: 'submission_completion'
+
       resource :review, only: %i[new create]
       get '/review/ingest_status_polling/', to: 'reviews#ingest_status_polling'
       get '/review/calculate_status_polling/', to: 'reviews#calculate_status_polling'

--- a/spec/features/task_management_spec.rb
+++ b/spec/features/task_management_spec.rb
@@ -31,6 +31,15 @@ RSpec.feature 'task management' do
     force_reload_to_get_updated_submission_status
 
     expect(page).to have_content 'Upload processed'
+
+    mock_complete_submission_endpoint!
+    mock_submission_completed_with_task_endpoint!
+    mock_submission_completed_endpoint!
+
+    click_on 'Complete submission'
+
+    expect(page).to have_content 'Submission completed'
+    expect(page).to have_flash_message "You have completed task 'test task'"
   end
 
   private

--- a/spec/fixtures/mocks/submission_completed_with_task.json
+++ b/spec/fixtures/mocks/submission_completed_with_task.json
@@ -1,0 +1,36 @@
+{
+  "data": {
+    "id": "9a5ef62c-0781-4f80-8850-5793652b6b40",
+    "type": "submissions",
+    "attributes": {
+      "framework_id": "f87717d4-874a-43d9-b99f-c8cf2897b526",
+      "supplier_id": "cd40ead8-67b5-4918-abf0-ab8937cd04ff",
+      "status": "completed",
+      "levy": 4500
+    },
+    "relationships": {
+      "task": {
+        "data": [
+          {
+            "type": "tasks",
+            "id": "2d98639e-5260-411f-a5ee-61847a2e067c"
+          }
+        ]
+      }
+    }
+  },
+  "included": [
+    {
+      "id": "2d98639e-5260-411f-a5ee-61847a2e067c",
+      "type": "tasks",
+      "attributes": {
+        "status": "completed",
+        "description": "test task",
+        "due_on": "2030-01-01",
+        "framework_id": "f87717d4-874a-43d9-b99f-c8cf2897b526",
+        "supplier_id": "cd40ead8-67b5-4918-abf0-ab8937cd04ff"
+      }
+    }
+  ]
+}
+

--- a/spec/support/api_helpers.rb
+++ b/spec/support/api_helpers.rb
@@ -31,11 +31,21 @@ module ApiHelpers
       .to_return(headers: json_headers, body: json_fixture_file('submission_completed.json'))
   end
 
+  def mock_submission_completed_with_task_endpoint!
+    stub_request(:get, 'https://ccs.api/v1/submissions/9a5ef62c-0781-4f80-8850-5793652b6b40?include=task')
+      .to_return(headers: json_headers, body: json_fixture_file('submission_completed_with_task.json'))
+  end
+
   def mock_submission_transitioning_to_in_review!
     stub_request(:get, 'https://ccs.api/v1/submissions/9a5ef62c-0781-4f80-8850-5793652b6b40?include=files,entries')
       .to_return(headers: json_headers, body: json_fixture_file('submission_with_entries_pending.json'))
       .then
       .to_return(headers: json_headers, body: json_fixture_file('submission_with_entries_validated.json'))
+  end
+
+  def mock_complete_submission_endpoint!
+    stub_request(:post, 'https://ccs.api/v1/submissions/9a5ef62c-0781-4f80-8850-5793652b6b40/complete')
+      .to_return(status: 204, body: '', headers: json_headers)
   end
 
   def mock_task_with_framework_endpoint!


### PR DESCRIPTION
After the user sees the submission summary page (which shows the number of rows ingested + the levy calculation) and they click the "Complete submission" button, which POSTs to the new
`SubmissionCompletionController#create`.

This calls the API to mark the submission as complete and then redirects to the submission's show page, which now shows the "submission completed" screen along with a flash message.