### PR TITLE
(224) Signed-in users see a different home page

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,5 +1,9 @@
 class HomeController < ApplicationController
   def index
-    # NO OP
+    if current_user
+      render :signed_in_homepage
+    else
+      render :guest_homepage
+    end
   end
 end

--- a/app/views/home/guest_homepage.html.haml
+++ b/app/views/home/guest_homepage.html.haml
@@ -21,7 +21,7 @@
       You will need your new account details. You should have received these details via email.
     %p
       = succeed '.' do
-        If you are unable to log in or have not received any account details, please contact support at
+        If you are unable to sign in or have not received any account details, please contact support at
         = link_to 'dss@crowncommercial.gov.uk', 'mailto:dss@crowncommercial.gov.uk'
     %p
       = link_to 'Sign in', '/auth/auth0'
@@ -29,10 +29,7 @@
     %p
       The deadline to submit your July 2018 data is 7 August.
 
-    - if current_user
-      = link_to 'Sign out', '/sign_out', class: 'button', id: 'sign-out'
-    - else
-      = link_to 'Sign in', '/auth/auth0', class: 'button', id: 'sign-in'
+    = link_to 'Sign in', '/auth/auth0', class: 'button', id: 'sign-in'
 
     %p
-      If you didn’t do any business, you still need to log in and let us know.
+      If you didn’t do any business, you still need to sign in and let us know.

--- a/app/views/home/signed_in_homepage.html.haml
+++ b/app/views/home/signed_in_homepage.html.haml
@@ -1,0 +1,19 @@
+%h1.heading-xlarge
+  Report management information to CCS
+
+.grid-row
+  .column-two-thirds
+    %p
+      = link_to 'View your tasks', tasks_path
+      to report your management information for this month.
+      If you didn’t do any business, you still need to let us know.
+
+    %p
+      = link_to 'Go to tasks', tasks_path, class: 'button'
+
+    %p
+      = succeed '.' do
+        If you are having problems reporting your management
+        information, please contact support at
+        = mail_to('dss@crowncommercial.gov.uk')
+

--- a/spec/features/users_can_sign_in_spec.rb
+++ b/spec/features/users_can_sign_in_spec.rb
@@ -20,7 +20,7 @@ RSpec.feature 'Signing in as a user' do
     click_on 'sign-in'
 
     visit '/'
-    click_on 'sign-out'
+    click_on 'Sign out email@example.com'
 
     expect(page).to have_content 'Sign in'
   end

--- a/spec/features/users_can_view_the_homepage_spec.rb
+++ b/spec/features/users_can_view_the_homepage_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.feature 'Viewing the homepage' do
+  context 'without signing in' do
+    scenario 'can see the introductory text' do
+      visit '/'
+
+      expect(page).to have_content 'Before you start'
+    end
+  end
+
+  context 'whilst signed in' do
+    scenario 'can see instructions for viewing tasks' do
+      mock_sso_with(email: 'email@example.com')
+      mock_tasks_endpoint!
+
+      visit '/'
+      click_link 'sign-in'
+      visit '/'
+
+      expect(page).to have_link 'View your tasks'
+      expect(page).to have_link 'Go to tasks'
+    end
+  end
+end


### PR DESCRIPTION
Show different content to signed-in users that links to their task list.

I've also changed 'log in' to 'sign in' on the guest home page.