### PR TITLE
(264) Add 'brakeman' to find potential vulnerabilities

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -17,6 +17,10 @@ Rails/HasManyOrHasOneDependent:
 Bundler/OrderedGems:
     Enabled: false
 
+Style/RedundantBegin:
+    Exclude:
+        - 'lib/active_storage/service/s3_with_metadata_service.rb'
+
 Style/Alias:
     Enabled: false
 

--- a/Gemfile
+++ b/Gemfile
@@ -52,6 +52,7 @@ gem 'simple_form'
 gem 'rollbar'
 
 group :development, :test do
+  gem 'brakeman', require: false
   gem 'byebug', platforms: %i[mri mingw x64_mingw]
   gem 'dotenv-rails'
   gem 'factory_bot_rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -64,6 +64,7 @@ GEM
     bindex (0.5.0)
     bootsnap (1.3.0)
       msgpack (~> 1.0)
+    brakeman (4.3.1)
     builder (3.2.3)
     byebug (10.0.2)
     capybara (3.1.1)
@@ -326,6 +327,7 @@ PLATFORMS
 DEPENDENCIES
   aws-sdk-s3
   bootsnap (>= 1.1.0)
+  brakeman
   byebug
   capybara
   coffee-rails (~> 4.2)

--- a/lib/active_storage/service/s3_with_metadata_service.rb
+++ b/lib/active_storage/service/s3_with_metadata_service.rb
@@ -3,9 +3,11 @@ require 'active_storage/service/s3_service'
 class ActiveStorage::Service::S3WithMetadataService < ActiveStorage::Service::S3Service
   def upload(key, io, checksum: nil, metadata: nil)
     instrument :upload, key: key, checksum: checksum do
-      object_for(key).put(upload_options.merge(body: io, content_md5: checksum, metadata: metadata))
-    rescue Aws::S3::Errors::BadDigest
-      raise ActiveStorage::IntegrityError
+      begin
+        object_for(key).put(upload_options.merge(body: io, content_md5: checksum, metadata: metadata))
+      rescue Aws::S3::Errors::BadDigest
+        raise ActiveStorage::IntegrityError
+      end
     end
   end
 end

--- a/lib/tasks/brakeman.rake
+++ b/lib/tasks/brakeman.rake
@@ -1,0 +1,15 @@
+if Rails.env.development? || Rails.env.test?
+  namespace :brakeman do
+    desc 'Run Brakeman'
+    task :run do
+      require 'brakeman'
+
+      Brakeman.run(
+        app_path: '.',
+        quiet: true,
+        pager: false,
+        print_report: true
+      )
+    end
+  end
+end

--- a/lib/tasks/default.rake
+++ b/lib/tasks/default.rake
@@ -1,0 +1,1 @@
+task default: %i[rubocop brakeman:run spec] if Rails.env.test? || Rails.env.development?

--- a/lib/tasks/rubocop.rake
+++ b/lib/tasks/rubocop.rake
@@ -1,13 +1,10 @@
 if Rails.env.development? || Rails.env.test?
-  require 'rubocop/rake_task'
-
   desc 'Run rubocop - configure in .rubocop.yml'
   task :rubocop do
+    require 'rubocop/rake_task'
+
     RuboCop::RakeTask.new(:rubocop) do |t|
       t.options = ['--display-cop-names']
     end
   end
-
-  task(:default).clear.enhance(%i[rubocop spec])
-  task(:default).comment = 'Run rubocop checks'
 end


### PR DESCRIPTION
This has been added to the default rake task that is run when you call
`bin/dspec` or `bin/drake` with no options. This will also be included
when CI gets run.

NB: I had to reorganise the rake tasks to ensure that RuboCop, RSpec and
Brakeman were run, as the original `rubocop.rake` was overwriting the
config.