### PR TITLE
Allow user to set a submission purchase order no.

### DIFF
--- a/app/assets/stylesheets/components/_all.scss
+++ b/app/assets/stylesheets/components/_all.scss
@@ -1,5 +1,6 @@
 // standard
 @import "govuk-frontend/components/file-upload/file-upload";
+@import "govuk-frontend/components/input/input";
 
 // custom
 @import "type/type";

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -23,7 +23,7 @@ class SubmissionsController < ApplicationController
   private
 
   def upload_file_submission(task, upload)
-    submission = API::Submission.create(task_id: task.id)
+    submission = API::Submission.create(task_id: task.id, purchase_order_number: params[:purchase_order_number])
     submission_file = API::SubmissionFile.create(submission_id: submission.id)
 
     blob = ActiveStorage::Blob.create_after_upload!(

--- a/app/views/submissions/in_review.html.haml
+++ b/app/views/submissions/in_review.html.haml
@@ -5,7 +5,10 @@
   .govuk-grid-column-two-thirds
 %p
   Your file has been checked and is ready to submit.
-
+- if @submission.purchase_order_number
+  %p.govuk-heading-s
+    Purchase order number:
+    = @submission.purchase_order_number
 %table.govuk-table
   %thead.govuk-table__head
     %tr.govuk-table__row

--- a/app/views/submissions/new.html.haml
+++ b/app/views/submissions/new.html.haml
@@ -1,17 +1,28 @@
-%h1.govuk-heading-xl
-  Upload a file
-
+.govuk-grid-row
+  .govuk-grid-column-full
+    %h1.govuk-heading-xl
+      Report management information
 .govuk-grid-row
   .govuk-grid-column-two-thirds
-    %p
-      Choose a file to upload.
+    %h2.govuk-heading-l
+      Choose a file
     %p
       Accepted file types are Microsoft Excel (.xls or .xlsx).
     %p
       You’ll be able to review a summary of the files before you submit.
-
     = form_tag(task_submissions_path(task_id: params[:task_id]), multipart: true) do
       .govuk-form-group
         = file_field_tag 'upload', required: true, class: 'govuk-file-upload'
+      %h2.govuk-heading-l
+        Provide a purchase order number
+      %p
+        You can optionally attach your own purchase order number to this submission
+        that will appear on your invoice.
+      .govuk-form-group
+        %label.govuk-label{ :for => 'purchase_order_number' }
+          Purchase order number
+        %span#purchase-order-number-hint.govuk-hint
+          This field is optional.
+        %input.govuk-input#purchase_order_number{ :type => 'text', :name => "purchase_order_number"}
       .govuk-form-group
         = submit_tag 'Upload and check file', class: 'govuk-button'

--- a/spec/features/task_management_spec.rb
+++ b/spec/features/task_management_spec.rb
@@ -17,7 +17,7 @@ RSpec.feature 'task management' do
 
     click_on 'Report management information'
 
-    expect(page).to have_content 'Upload a file'
+    expect(page).to have_content 'Choose a file'
 
     attach_file :upload, example_submission_file
 

--- a/spec/fixtures/mocks/submission_completed.json
+++ b/spec/fixtures/mocks/submission_completed.json
@@ -5,6 +5,7 @@
     "attributes": {
       "framework_id": "f87717d4-874a-43d9-b99f-c8cf2897b526",
       "supplier_id": "cd40ead8-67b5-4918-abf0-ab8937cd04ff",
+      "purchase_order_number": null,
       "status": "completed",
       "levy": 4500
     },

--- a/spec/fixtures/mocks/submission_completed_with_task.json
+++ b/spec/fixtures/mocks/submission_completed_with_task.json
@@ -5,6 +5,7 @@
     "attributes": {
       "framework_id": "f87717d4-874a-43d9-b99f-c8cf2897b526",
       "supplier_id": "cd40ead8-67b5-4918-abf0-ab8937cd04ff",
+      "purchase_order_number": "PO123",
       "status": "completed",
       "levy": 4500
     },

--- a/spec/fixtures/mocks/submission_pending.json
+++ b/spec/fixtures/mocks/submission_pending.json
@@ -5,6 +5,7 @@
     "attributes": {
       "framework_id": "f87717d4-874a-43d9-b99f-c8cf2897b526",
       "supplier_id": "cd40ead8-67b5-4918-abf0-ab8937cd04ff",
+      "purchase_order_number": null,
       "status": "pending"
     },
     "relationships": {

--- a/spec/fixtures/mocks/submission_with_entries_errored.json
+++ b/spec/fixtures/mocks/submission_with_entries_errored.json
@@ -5,6 +5,7 @@
     "attributes": {
       "framework_id": "f87717d4-874a-43d9-b99f-c8cf2897b526",
       "supplier_id": "cd40ead8-67b5-4918-abf0-ab8937cd04ff",
+      "purchase_order_number": null,
       "status": "validation_failed",
       "levy": null
     },

--- a/spec/fixtures/mocks/submission_with_entries_pending.json
+++ b/spec/fixtures/mocks/submission_with_entries_pending.json
@@ -5,6 +5,7 @@
     "attributes": {
       "framework_id": "f87717d4-874a-43d9-b99f-c8cf2897b526",
       "supplier_id": "cd40ead8-67b5-4918-abf0-ab8937cd04ff",
+      "purchase_order_number": null,
       "status": "processing"
     },
     "relationships": {

--- a/spec/fixtures/mocks/submission_with_entries_validated.json
+++ b/spec/fixtures/mocks/submission_with_entries_validated.json
@@ -5,6 +5,7 @@
     "attributes": {
       "framework_id": "f87717d4-874a-43d9-b99f-c8cf2897b526",
       "supplier_id": "cd40ead8-67b5-4918-abf0-ab8937cd04ff",
+      "purchase_order_number": "123",
       "status": "in_review",
       "levy": 4500
     },


### PR DESCRIPTION
Many suppliers require that invoices they receive include a purchase
order number for them to be payable via their finance system. This makes
it possible for a supplier to include a purchase order number against a
submission.