### PR TITLE
Use newly exposed entry counts on review page

### DIFF
--- a/app/models/api/submission.rb
+++ b/app/models/api/submission.rb
@@ -10,14 +10,6 @@ module API
     # POST /submissions/:id/complete
     custom_endpoint :complete, on: :member, request_method: :post
 
-    def orders_count
-      entries.count { |entry| entry.source['sheet'].match?(/order/i) }
-    end
-
-    def invoices_count
-      entries.count { |entry| entry.source['sheet'].match?(/invoice/i) }
-    end
-
     def errored_entries
       @errored_entries ||= entries.select { |entry| entry.status == 'errored' }
     end

--- a/app/views/submissions/in_review.html.haml
+++ b/app/views/submissions/in_review.html.haml
@@ -20,9 +20,9 @@
       %td.govuk-table__cell
         Uploaded file
       %td.govuk-table__cell
-        = @submission.invoices_count
+        = @submission.invoice_count
       %td.govuk-table__cell
-        = @submission.orders_count
+        = @submission.order_count
 
 = form_tag(task_submission_complete_path(task_id: @task.id, submission_id: @submission.id), method: :post) do
   .form-group

--- a/spec/fixtures/mocks/submission_completed.json
+++ b/spec/fixtures/mocks/submission_completed.json
@@ -5,6 +5,8 @@
     "attributes": {
       "framework_id": "f87717d4-874a-43d9-b99f-c8cf2897b526",
       "supplier_id": "cd40ead8-67b5-4918-abf0-ab8937cd04ff",
+      "invoice_count": 2,
+      "order_count": 1,
       "purchase_order_number": null,
       "status": "completed",
       "levy": 4500

--- a/spec/fixtures/mocks/submission_completed_with_task.json
+++ b/spec/fixtures/mocks/submission_completed_with_task.json
@@ -5,6 +5,8 @@
     "attributes": {
       "framework_id": "f87717d4-874a-43d9-b99f-c8cf2897b526",
       "supplier_id": "cd40ead8-67b5-4918-abf0-ab8937cd04ff",
+      "invoice_count": 2,
+      "order_count": 1,
       "purchase_order_number": "PO123",
       "status": "completed",
       "levy": 4500

--- a/spec/fixtures/mocks/submission_pending.json
+++ b/spec/fixtures/mocks/submission_pending.json
@@ -5,6 +5,8 @@
     "attributes": {
       "framework_id": "f87717d4-874a-43d9-b99f-c8cf2897b526",
       "supplier_id": "cd40ead8-67b5-4918-abf0-ab8937cd04ff",
+      "invoice_count": 0,
+      "order_count": 0,
       "purchase_order_number": null,
       "status": "pending"
     },

--- a/spec/fixtures/mocks/submission_with_entries_errored.json
+++ b/spec/fixtures/mocks/submission_with_entries_errored.json
@@ -5,6 +5,8 @@
     "attributes": {
       "framework_id": "f87717d4-874a-43d9-b99f-c8cf2897b526",
       "supplier_id": "cd40ead8-67b5-4918-abf0-ab8937cd04ff",
+      "invoice_count": 2,
+      "order_count": 1,
       "purchase_order_number": null,
       "status": "validation_failed",
       "levy": null

--- a/spec/fixtures/mocks/submission_with_entries_pending.json
+++ b/spec/fixtures/mocks/submission_with_entries_pending.json
@@ -5,6 +5,8 @@
     "attributes": {
       "framework_id": "f87717d4-874a-43d9-b99f-c8cf2897b526",
       "supplier_id": "cd40ead8-67b5-4918-abf0-ab8937cd04ff",
+      "invoice_count": 1,
+      "order_count": 0,
       "purchase_order_number": null,
       "status": "processing"
     },

--- a/spec/fixtures/mocks/submission_with_entries_validated.json
+++ b/spec/fixtures/mocks/submission_with_entries_validated.json
@@ -5,6 +5,8 @@
     "attributes": {
       "framework_id": "f87717d4-874a-43d9-b99f-c8cf2897b526",
       "supplier_id": "cd40ead8-67b5-4918-abf0-ab8937cd04ff",
+      "invoice_count": 2,
+      "order_count": 1,
       "purchase_order_number": "123",
       "status": "in_review",
       "levy": 4500

--- a/spec/models/api/submission_spec.rb
+++ b/spec/models/api/submission_spec.rb
@@ -3,24 +3,6 @@ require 'rails_helper'
 RSpec.describe API::Submission do
   include ApiHelpers
 
-  describe '#orders_count' do
-    let(:submission) { API::Submission.includes(:entries).find(mock_submission_id).first }
-
-    it 'returns the number of entries against sheets containing the word "order"' do
-      mock_submission_with_entries_validated_endpoint!
-      expect(submission.orders_count).to eq 1
-    end
-  end
-
-  describe '#invoices_count' do
-    let(:submission) { API::Submission.includes(:entries).find(mock_submission_id).first }
-
-    it 'returns the number of entries against sheets containing the word "invoice"' do
-      mock_submission_with_entries_validated_endpoint!
-      expect(submission.invoices_count).to eq 2
-    end
-  end
-
   describe '#errored_entries' do
     let(:submission) { API::Submission.includes(:entries).find(mock_submission_id).first }
 


### PR DESCRIPTION
The API as of [PR #61] exposes counts for the number of invoices and orders, which means we no longer need to include all the entries to be able to summarise the submission.

[PR #61]: https://github.com/dxw/DataSubmissionServiceAPI/pull/61