### PR TITLE
Add utility code and docs for adding new users

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,6 +51,9 @@ gem 'simple_form'
 # Exception tracking
 gem 'rollbar'
 
+# Auth0 client for user setup scripts
+gem 'auth0', require: false
+
 group :development, :test do
   gem 'brakeman', require: false
   gem 'byebug', platforms: %i[mri mingw x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -46,6 +46,8 @@ GEM
       public_suffix (>= 2.0.2, < 4.0)
     arel (9.0.0)
     ast (2.4.0)
+    auth0 (4.5.0)
+      rest-client (~> 2.0)
     aws-eventstream (1.0.0)
     aws-partitions (1.91.0)
     aws-sdk-core (3.21.2)
@@ -89,6 +91,8 @@ GEM
     crass (1.0.4)
     database_cleaner (1.7.0)
     diff-lcs (1.3)
+    domain_name (0.5.20180417)
+      unf (>= 0.0.5, < 1.0.0)
     dotenv (2.4.0)
     dotenv-rails (2.4.0)
       dotenv (= 2.4.0)
@@ -131,6 +135,8 @@ GEM
       haml (>= 4.0, < 6)
       nokogiri (>= 1.6.0)
       ruby_parser (~> 3.5)
+    http-cookie (1.0.3)
+      domain_name (~> 0.5)
     httparty (0.16.2)
       multi_xml (>= 0.5.2)
     i18n (1.0.1)
@@ -163,6 +169,9 @@ GEM
     marcel (0.3.2)
       mimemagic (~> 0.3.2)
     method_source (0.9.0)
+    mime-types (3.2.2)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2018.0812)
     mimemagic (0.3.2)
     mini_mime (1.0.0)
     mini_portile2 (2.3.0)
@@ -173,6 +182,7 @@ GEM
     multi_json (1.13.1)
     multi_xml (0.6.0)
     multipart-post (2.0.0)
+    netrc (0.11.0)
     nio4r (2.3.1)
     nokogiri (1.8.4)
       mini_portile2 (~> 2.3.0)
@@ -238,6 +248,10 @@ GEM
     rb-fsevent (0.10.3)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
+    rest-client (2.0.2)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 4.0)
+      netrc (~> 0.8)
     rollbar (2.16.4)
       multi_json
     rspec-core (3.7.1)
@@ -304,6 +318,9 @@ GEM
       thread_safe (~> 0.1)
     uglifier (4.1.10)
       execjs (>= 0.3.0, < 3)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.7.5)
     unicode-display_width (1.3.2)
     web-console (3.6.2)
       actionview (>= 5.0)
@@ -325,6 +342,7 @@ PLATFORMS
   x86_64-darwin-17
 
 DEPENDENCIES
+  auth0
   aws-sdk-s3
   bootsnap (>= 1.1.0)
   brakeman
@@ -365,4 +383,4 @@ RUBY VERSION
    ruby 2.5.1p57
 
 BUNDLED WITH
-   1.16.3
+   1.16.4

--- a/app/models/auth0_authenticated_user.rb
+++ b/app/models/auth0_authenticated_user.rb
@@ -1,0 +1,41 @@
+# Used to create a new User record, setting up the required authorisation in
+# Auth0, the current authentication service.
+#
+# See docs/setting-up-new-users.md for example usage
+class Auth0AuthenticatedUser
+  AUTH0_DATABASE_BASED_CONNECTION_NAME = 'Username-Password-Authentication'.freeze
+
+  attr_reader :auth0_client, :full_name, :email, :supplier_name, :supplier_id
+
+  def initialize(auth0_client, full_name, email, supplier_name, supplier_id)
+    @auth0_client = auth0_client
+    @full_name = full_name
+    @email = email
+    @supplier_name = supplier_name
+    @supplier_id = supplier_id
+  end
+
+  def create!
+    auth0_response = auth0_client.create_user(full_name, auth0_create_options)
+    User.create!(email: email, uid: auth0_response.fetch('user_id'))
+  end
+
+  private
+
+  def auth0_create_options
+    {
+      email: email,
+      email_verified: true,
+      password: random_password,
+      connection: AUTH0_DATABASE_BASED_CONNECTION_NAME,
+      app_metadata: {
+        supplier: supplier_name,
+        supplier_id: supplier_id
+      }
+    }
+  end
+
+  def random_password
+    SecureRandom.urlsafe_base64
+  end
+end

--- a/docs/setting-up-new-users.md
+++ b/docs/setting-up-new-users.md
@@ -1,0 +1,58 @@
+# Setting up new users
+
+At present adding new users to Report MI is a three stage process:
+
+  1. Add the users to Auth0
+  2. Add Users record to the frontend application, mapping to the Auth0 user ID
+  3. Add Membership records in the API, mapping the User IDs in the frontend
+     application to the supplier IDs in the API
+
+(Note: there is technically a step 0, which is to add the users' suppliers to
+the API. For an example of how to do that, see this [data migration for adding suppliers].)
+
+Steps 1 and 2 can be performed using the `Auth0AuthenticatedUser` utility
+class.
+
+Below is an example Ruby script demonstrating its use. It assumes the following:
+
+- There is a CSV file containing the user details with headers: Supplier Name,
+  User Name, Email
+- There is a hash mapping supplier names to their IDs in the API, as output by
+  the example [data migration for adding suppliers]
+- AUTH0 environment variables are set, including one called `AUTH0_API_TOKEN`
+  that contains a valid API token. One can be acquired from "API Explorer" tab
+  in the API section of Auth0.
+
+```ruby
+require 'auth0'
+require 'csv'
+
+# set this based on the output from the supplier data migration that is run on the API
+SUPPLIER_NAME_TO_ID_MAP = { "Supplier Name" => "UUID_FOR_SUPPLIER",... }
+# CSV file containing: Supplier Name,User Name,Email
+USERS_CSV_PATH = Rails.root.join('tmp', 'users.csv')
+
+auth0_client = Auth0Client.new(
+  client_id: ENV['AUTH0_CLIENT_ID'],
+  domain: ENV['AUTH0_DOMAIN'],
+  token: ENV['AUTH0_API_TOKEN'], # This needs to be generated/acquired from Auth0
+  api_version: 2
+)
+
+CSV.read(USERS_CSV_PATH, headers: true, header_converters: :symbol).each do |row|
+  user_name = row.fetch(:user_name)
+  email = row.fetch(:email)
+  supplier_name = row.fetch(:supplier_name)
+  supplier_id = SUPPLIER_NAME_TO_ID_MAP.fetch(supplier_name)
+
+  auth0_authenticated_user = Auth0AuthenticatedUser.new(auth0_client, user_name, email, supplier_name, supplier_id)
+  user = auth0_authenticated_user.create!
+
+  puts "Membership.create!(user_id: '#{user.id}', supplier_id: '#{supplier_id}')"
+```
+
+Note that this script also outputs Rails code that can be run on the API
+console to complete Step 3, i.e. create the memberships mapping the user back
+to their supplier.
+
+[data migration for adding suppliers]:https://github.com/dxw/DataSubmissionServiceAPI/tree/develop/db/data_migrate/20180924143116_add_october_suppliers.rb

--- a/spec/models/auth0_authenticated_user_spec.rb
+++ b/spec/models/auth0_authenticated_user_spec.rb
@@ -1,0 +1,57 @@
+require 'rails_helper'
+
+RSpec.describe Auth0AuthenticatedUser do
+  let(:auth0_client) { instance_double('Auth0 client') }
+  let(:auth0_create_user_response) do
+    {
+      'email' => email,
+      'email_verified' => true,
+      'name' => user_name,
+      'updated_at' => '2018-09-25T12:19:46.006Z',
+      'picture' => 'https://s.gravatar.com/avatar/1234.png',
+      'user_id' => 'auth0|12345',
+      'nickname' => user_name,
+      'identities' => [
+        {
+          'connection' => 'Username-Password-Authentication',
+          'user_id' => '12345',
+          'provider' => 'auth0',
+          'isSocial' => false
+        }
+      ],
+      'created_at' => '2018-09-25T12:19:46.006Z',
+      'app_metadata' => { 'supplier' => supplier_name, 'supplier_id' => supplier_id }
+    }
+  end
+  let(:user_name) { 'Test User' }
+  let(:email) { 'test@user.com' }
+  let(:supplier_name) { 'DXW' }
+  let(:supplier_id) { '123456' }
+  let(:auth0_authenticated_user) do
+    Auth0AuthenticatedUser.new(auth0_client, user_name, email, supplier_name, supplier_id)
+  end
+
+  describe '#create' do
+    it 'creates the user on Auth0 and creates a corresponding database record matching the auth0 user id' do
+      expect(auth0_client).to receive(:create_user).with(
+        user_name,
+        a_hash_including(
+          email: email,
+          email_verified: true,
+          password: kind_of(String),
+          connection: Auth0AuthenticatedUser::AUTH0_DATABASE_BASED_CONNECTION_NAME,
+          app_metadata: {
+            supplier: supplier_name,
+            supplier_id: supplier_id
+          }
+        )
+      ).and_return(auth0_create_user_response)
+
+      user = auth0_authenticated_user.create!
+
+      expect(user).to be_persisted
+      expect(user.email).to eq 'test@user.com'
+      expect(user.uid).to eq 'auth0|12345'
+    end
+  end
+end


### PR DESCRIPTION
This adds documentation and supporting code for setting up new users on
the Report MI system so that they are able to sign in and make
submissions against their supplier's tasks. For GDPR reasons, a CSV for
October onboarding is not included here in the repository as it would
contain PPI for users.

The process is:

  - set up a user in Auth0
  - add a User record to the frontend database, including their Auth0
    ID, which makes it possible for the user to log in using Auth0.
  - Associate the newly created record with their Supplier in the API
    by creating a Membership record

When adding the user to Auth0 we set a random password and the user is
asked to use the "reset password" functionality in Auth0 to choose their
own the first time they attempt to log in (they are invited to do so manually).

We also set the supplier name and ID for each user in their Auth0 app
metadata so that they are available in the admin interface for Auth0 to
aid in support requests.

There is a corresponding PR that will add suppliers for the October migration: https://github.com/dxw/DataSubmissionServiceAPI/pull/71 