### PR TITLE
Lock to yarn 1.9.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER dxw <rails@dxw.com>
 
 RUN apt-get update && apt-get install -qq -y build-essential libpq-dev nodejs --fix-missing --no-install-recommends
 
-RUN YARN_VERSION=$(curl -sSL --compressed https://yarnpkg.com/latest-version) \
+RUN YARN_VERSION=1.9.4 \
   set -ex \
   && curl -fSLO --compressed "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz" \
   && mkdir -p /opt/yarn \


### PR DESCRIPTION
The [AWS build] is braking with the latest version of yarn (1.10.0) in a way that we don't understand. To get the build green again so we can hit our October deadline we're going to lock to the known good version of yarn.

[AWS build]: https://eu-west-2.console.aws.amazon.com/codebuild/home?region=eu-west-2#/builds/DataSubmissionService%253Ac2d70c9e-0146-4c9a-a503-80cd290be43b/view/new