### PR TITLE
Repurpose Task#description to expose supplier name where necessary

### DIFF
--- a/app/assets/stylesheets/components/task/_task.scss
+++ b/app/assets/stylesheets/components/task/_task.scss
@@ -4,7 +4,7 @@
   border-top: 1px solid govuk-colour("grey-2");
   padding-top: govuk-spacing(5);
   background-color: govuk-colour("white");
-  h3 {
+  h3, h5 {
     margin-bottom: govuk-spacing(1);
   }
   .ccs-task__information {

--- a/app/helpers/submissions_helper.rb
+++ b/app/helpers/submissions_helper.rb
@@ -2,4 +2,11 @@ module SubmissionsHelper
   def potentially_truncated_errors(submission)
     submission.sheet_errors.any? { |_sheet_key, errors| errors.size >= 10 }
   end
+
+  def submission_completed_text(task)
+    [
+      task.description,
+      "management information for #{task.framework.short_name} #{task.framework.name} submitted to CCS"
+    ].compact.join(' ').upcase_first
+  end
 end

--- a/app/views/shared/_task_signpost.html.haml
+++ b/app/views/shared/_task_signpost.html.haml
@@ -1,5 +1,8 @@
 %aside.ccs-task_signpost
-	%h2
-		Report management information for
-		= framework.short_name
-		= framework.name
+  %h2
+    - if task.description.present?
+      = task.description
+      %br
+    Report management information for
+    = task.framework.short_name
+    = task.framework.name

--- a/app/views/submissions/completed.html.haml
+++ b/app/views/submissions/completed.html.haml
@@ -2,6 +2,7 @@
   .govuk-grid-column-two-thirds
     .govuk-panel.govuk-panel--confirmation
       %h1.govuk-panel__title
+        = @task.description
         Management information for
         = @task.framework.short_name
         = @task.framework.name

--- a/app/views/submissions/in_review.html.haml
+++ b/app/views/submissions/in_review.html.haml
@@ -1,6 +1,6 @@
 .govuk-grid-row
   .govuk-grid-column-full
-    = render 'shared/task_signpost', framework: @task.framework
+    = render 'shared/task_signpost', task: @task
 
 .govuk-grid-row
   .govuk-grid-column-full

--- a/app/views/submissions/new.html.haml
+++ b/app/views/submissions/new.html.haml
@@ -1,6 +1,6 @@
 .govuk-grid-row
   .govuk-grid-column-full
-    = render 'shared/task_signpost', framework: @task.framework
+    = render 'shared/task_signpost', task: @task
 
 .govuk-grid-row
   .govuk-grid-column-full

--- a/app/views/submissions/processing.html.haml
+++ b/app/views/submissions/processing.html.haml
@@ -2,7 +2,7 @@
 
 .govuk-grid-row
   .govuk-grid-column-full
-    = render 'shared/task_signpost', framework: @task.framework
+    = render 'shared/task_signpost', task: @task
 
 .govuk-grid-row
   .govuk-grid-column-full

--- a/app/views/submissions/validation_failed.html.haml
+++ b/app/views/submissions/validation_failed.html.haml
@@ -1,6 +1,6 @@
 .govuk-grid-row
   .govuk-grid-column-full
-    = render 'shared/task_signpost', framework: @task.framework
+    = render 'shared/task_signpost', task: @task
 
 .govuk-grid-row
   .govuk-grid-column-full

--- a/app/views/tasks/_task.html.haml
+++ b/app/views/tasks/_task.html.haml
@@ -8,6 +8,9 @@
       - if task.late?
         %strong.govuk-tag.govuk-tag__warning Late
     .ccs-task__body
+      - if task.description.present?
+        %h5.govuk-body
+          = task.description
       %h3.govuk-heading-m
         = task.framework.short_name
         = task.framework.name

--- a/spec/fixtures/mocks/task_with_framework.json
+++ b/spec/fixtures/mocks/task_with_framework.json
@@ -3,7 +3,7 @@
     "id": "2d98639e-5260-411f-a5ee-61847a2e067c",
     "type": "tasks",
     "attributes": {
-      "description": "test task",
+      "description": null,
       "due_on": "2030-01-01",
       "period_month": 7,
       "period_year": 2018,

--- a/spec/fixtures/mocks/tasks_with_framework_and_latest_submission.json
+++ b/spec/fixtures/mocks/tasks_with_framework_and_latest_submission.json
@@ -7,7 +7,7 @@
         "status": "unstarted",
         "framework_id": "dafc084d-eb8b-42ac-ae56-4eee42be8ef1",
         "supplier_id": "533a1357-4faf-4ced-b759-3e6da0bc5f3e",
-        "description": "Unstarted task",
+        "description": null,
         "due_on": "2018-08-07",
         "period_year": 2018,
         "period_month": 7
@@ -36,7 +36,7 @@
         "status": "in_progress",
         "framework_id": "21e4a516-9852-49fd-9035-8006bdf76657",
         "supplier_id": "533a1357-4faf-4ced-b759-3e6da0bc5f3e",
-        "description": "In progress task (pending submission)",
+        "description": "Some arbitrary task description",
         "due_on": "2018-08-07",
         "period_year": 2018,
         "period_month": 7
@@ -68,7 +68,7 @@
         "status": "in_progress",
         "framework_id": "ec2aed23-7c4f-4de8-b4ad-afc54ecf882d",
         "supplier_id": "533a1357-4faf-4ced-b759-3e6da0bc5f3e",
-        "description": "In progress task (processing submission)",
+        "description": null,
         "due_on": "2018-08-07",
         "period_year": 2018,
         "period_month": 7
@@ -100,7 +100,7 @@
         "status": "in_progress",
         "framework_id": "fbe9c2dd-ad80-4398-8c92-f50a6a47d92e",
         "supplier_id": "533a1357-4faf-4ced-b759-3e6da0bc5f3e",
-        "description": "In review task (validated submission)",
+        "description": null,
         "due_on": "2018-09-07",
         "period_year": 2018,
         "period_month": 8
@@ -132,7 +132,7 @@
         "status": "in_progress",
         "framework_id": "7a50a178-3fb8-4c0a-9f2c-8841812448d1",
         "supplier_id": "533a1357-4faf-4ced-b759-3e6da0bc5f3e",
-        "description": "In review task (invalid submission)",
+        "description": null,
         "due_on": "2018-08-07",
         "period_year": 2018,
         "period_month": 7
@@ -164,7 +164,7 @@
         "status": "completed",
         "framework_id": "485c9fdd-cfc9-4b3c-9a69-a8195f9c13bc",
         "supplier_id": "533a1357-4faf-4ced-b759-3e6da0bc5f3e",
-        "description": "Completed task",
+        "description": null,
         "due_on": "2018-08-07",
         "period_year": 2018,
         "period_month": 7

--- a/spec/helpers/submissions_helper_spec.rb
+++ b/spec/helpers/submissions_helper_spec.rb
@@ -34,6 +34,32 @@ RSpec.describe SubmissionsHelper do
     end
   end
 
+  describe '#submission_completed_text' do
+    before { mock_task_with_framework_endpoint! }
+
+    context 'given a task without a description' do
+      let(:task) { API::Task.includes(:framework).find(mock_task_id).first }
+
+      it 'includes the task name and shortname in the message' do
+        expect(helper.submission_completed_text(task))
+          .to eql 'Management information for CBOARD5 Cheese Board 5 submitted to CCS'
+      end
+    end
+
+    context 'given a task with a description' do
+      let(:task) do
+        API::Task.includes(:framework).find(mock_task_id).first.tap do |task|
+          allow(task).to receive(:description).and_return('Company Name')
+        end
+      end
+
+      it 'prefixes the messaage with the description with appropriate capitalisation' do
+        expect(helper.submission_completed_text(task))
+          .to eql 'Company Name management information for CBOARD5 Cheese Board 5 submitted to CCS'
+      end
+    end
+  end
+
   private
 
   def another_error

--- a/spec/requests/tasks_spec.rb
+++ b/spec/requests/tasks_spec.rb
@@ -81,6 +81,14 @@ RSpec.describe 'the tasks list' do
                       text: 'Download template'
       end
     end
+
+    it 'displays the task description when present' do
+      task_with_description_id = 'fc9deeb0-9804-42f7-ad8b-8b9878cce252'
+
+      assert_select "#task-#{task_with_description_id}" do
+        assert_select 'h5', text: 'Some arbitrary task description'
+      end
+    end
   end
 
   context 'when signed-in as a user with no tasks' do


### PR DESCRIPTION
We discovered late in the day that there are some users onboarding in October that need to have access to tasks for more than one supplier. This relationship is possible in the API application (i.e. a user can be associated with more than one supplier), but unfortunately the frontend application is currently designed with the assumption that a user will only see tasks for one supplier. Therefor a user that has access to multiple suppliers on the same framework will see duplicate tasks for those frameworks with no way to tell which supplier they are for. 

So that a user is able to distinguish identical tasks across multiple suppliers, we are hijacking the `Task#description` field. When the tasks are seeded for October in the API, any tasks that are for a supplier that has users shared with another supplier will have their description attribute set to the supplier's name. This way we can show this description and the user will be able to see the supplier name alongside each task where appropriate:

<img width="841" alt="screen shot 2018-09-26 at 20 48 16" src="https://user-images.githubusercontent.com/3687/46105302-a5dd4b80-c1cd-11e8-9c3b-1c24c774af46.png">

Note that this is very much a temporary solution (both from a UX and technical perspective) because of the short amount of time we have before the October submission window opens. A better (although still temporary) technical solution would be to expose the supplier association itself in the JSON API alongside each task, but that would require considerable more development effort on both the API side (to expose the associated supplier) and the frontend (to interpret the updated JSON API response). A high-priority story will be added to the backlog for a more long-term solution to multi-supplier support.