### PR TITLE
Replace public URN list with 2018-01-01 version

### DIFF
--- a/app/views/urns/index.html.haml
+++ b/app/views/urns/index.html.haml
@@ -10,9 +10,9 @@
       URN, you can look it up in this Excel file:
 
     %p
-      = link_to 'Download CCS URN List (September 2018).xls',
-        '/urn/CCS URN List (September 2018).xls'
-      (12.9MB)
+      = link_to 'Download CCS URN List (01 October 2018).xls',
+        '/urn/CCS-URN-List-(01-October-2018).xls'
+      (4.9MB)
 
     %p
       Open this file in Microsoft Excel and use the 'find' tool within Excel to

--- a/spec/requests/urns_spec.rb
+++ b/spec/requests/urns_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe 'the urns page' do
     get urns_path
 
     expect(response).to be_successful
-    assert_select 'a[href=?]', '/urn/CCS URN List (September 2018).xls',
-                  text: 'Download CCS URN List (September 2018).xls'
+    assert_select 'a[href=?]', '/urn/CCS-URN-List-(01-October-2018).xls',
+                  text: 'Download CCS URN List (01 October 2018).xls'
   end
 end


### PR DESCRIPTION
This PR updates the publicly downloadable URN list.

The new version removes unneeded fields (which reduces the file size).

As part of this, I've also changed the file naming convention so we can handle more than one update a month and also remove the spaces in the file name.