### PR TITLE
(476) Reduce logging in production

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,6 +51,9 @@ gem 'simple_form'
 # Exception tracking
 gem 'rollbar'
 
+# Logging
+gem 'lograge'
+
 # Auth0 client for user setup scripts
 gem 'auth0', require: false
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -161,6 +161,11 @@ GEM
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
       ruby_dep (~> 1.2)
+    lograge (0.10.0)
+      actionpack (>= 4)
+      activesupport (>= 4)
+      railties (>= 4)
+      request_store (~> 1.0)
     loofah (2.2.2)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -248,6 +253,8 @@ GEM
     rb-fsevent (0.10.3)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
+    request_store (1.4.1)
+      rack (>= 1.4)
     rest-client (2.0.2)
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
@@ -360,6 +367,7 @@ DEPENDENCIES
   jquery-rails
   jsonapi-consumer (~> 1.0)
   listen (>= 3.0.5, < 3.2)
+  lograge
   mini_racer
   omniauth
   omniauth-auth0 (~> 2.0.0)

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -46,10 +46,25 @@ Rails.application.configure do
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.
-  config.log_level = :debug
+  config.log_level = :info
 
   # Prepend all log lines with the following tags.
   config.log_tags = [:request_id]
+
+  # Don't log SQL in production
+  config.active_record.logger = nil
+
+  # Use lograge for cleaner logging
+  config.lograge.enabled = true
+  config.lograge.logger = ActiveSupport::Logger.new(STDOUT)
+
+  config.lograge.custom_options = lambda do |event|
+    exceptions = ['controller', 'action', 'format', 'id']
+
+    {
+      params: event.payload[:params].except(*exceptions)
+    }
+  end
 
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store


### PR DESCRIPTION
Now we've updated the API to use lograge single line logging, let's do
the same for the app. It'll make the logs easier to search too.

 - Stop logging SQL queries
 - Use lograge so that one request = one log line (also making it easier
   to search!)
 - Reduce log_level from 'debug' to 'info' in production(!)

This is the frontend companion to https://github.com/dxw/DataSubmissionServiceAPI/pull/87