### PR TITLE
Add component called task_signpost to No Business

### DIFF
--- a/app/views/no_businesses/new.html.haml
+++ b/app/views/no_businesses/new.html.haml
@@ -1,5 +1,9 @@
 .govuk-grid-row
   .govuk-grid-column-full
+    = render 'shared/task_signpost', task: @task, action: 'Report no business for'
+
+.govuk-grid-row
+  .govuk-grid-column-full
     %h1.govuk-heading-xl
       Report no business
 

--- a/app/views/shared/_task_signpost.html.haml
+++ b/app/views/shared/_task_signpost.html.haml
@@ -3,6 +3,6 @@
     - if task.description.present?
       = task.description
       %br
-    Report management information for
+    = local_assigns.fetch(:action, 'Report management information for')
     = task.framework.short_name
     = task.framework.name


### PR DESCRIPTION
Using the same task_signpost component created for RMI, in order to be able to change the title thats associated with No Business view,  I modified the task_signpost component partial, using local assigns to fetch the action of the title. The title can then be modified in the No Business view, by calling action and a new title

Added the component into the No Business view