### PR TITLE
400 How do we stop the home page getting unwieldy as we add new frameworks?

### DIFF
--- a/app/assets/stylesheets/components/_all.scss
+++ b/app/assets/stylesheets/components/_all.scss
@@ -5,6 +5,7 @@
 @import "govuk-frontend/components/phase-banner/phase-banner";
 @import "govuk-frontend/components/table/table";
 @import "govuk-frontend/components/error-summary/error-summary";
+@import "govuk-frontend/components/back-link/back-link";
 
 // custom
 @import "type/type";

--- a/app/controllers/support_controller.rb
+++ b/app/controllers/support_controller.rb
@@ -2,4 +2,8 @@ class SupportController < ApplicationController
   skip_before_action :ensure_user_signed_in
 
   def index; end
+
+  def frameworks
+    render :frameworks
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -4,7 +4,7 @@ module ApplicationHelper
   end
 
   def support_email_address
-    'dss@crowncommercial.gov.uk'
+    'report-mi@crowncommercial.gov.uk'
   end
 
   def task_status(task)

--- a/app/views/home/guest_homepage.html.haml
+++ b/app/views/home/guest_homepage.html.haml
@@ -6,41 +6,58 @@
 .govuk-grid-row
   .govuk-grid-column-two-thirds
     %p
-      Use this service to report on the following frameworks:
+      Use this service to:
 
-    %ul.govuk-list.govuk-list--bullet
-      %li RM3756 Rail Legal Services
-      %li RM3786 General Legal Services
-      %li RM3787 Finance & Complex Legal Services
-      %li RM807 Vehicle Hire
-      %li RM849 Laundry and Linen Services
-      %li RM858 Pan Government Vehicle Leasing and Fleet Outsource Solutions
-      %li RM1031 Laundry and Linen Services
-      %li RM1070 Vehicle Purchase
-      %li RM3710 Vehicle Lease and Fleet Management
-      %li RM3754 Vehicle Telematics
-      %li RM3767 Supply and Fit of Tyres
-      %li RM3772 Specialist Laundry Services
-      %li RM3797 Journal Subscriptions
-      %li CM/OSG/05/3565 Laundry Services Wave 2
-
+    %ul{ :class => 'govuk-list govuk-list--bullet' }
+      %li
+        get the template for your framework(s)
+      %li
+        report your management information to CCS for
+        = link_to('certain frameworks', '/support/frameworks')
+      %li
+        report no business to CCS
     %p
-      If you are reporting on any other framework, use the existing MISO service -
-      = link_to 'https://miso.ccs.cabinetoffice.gov.uk/', 'https://miso.ccs.cabinetoffice.gov.uk/'
+      If you didn’t do any business, you still need to sign in and let us know.
+
+    = link_to 'Start now', '/auth/auth0', class: 'govuk-button govuk-button--start', id: 'start-now'
 
     %h2.govuk-heading-m
       Before you start
+
+    %h3.govuk-heading-s
+      Your account
+
     %p
-      You should have received instructions on how to sign in for the first time by email.
+      You’ll need your username and password to sign in to this service.
+
     %p
+      Your username is the email address that Report Management Information sends notifications to.
+
+    %p
+      If you don’t know or have forgotten your password you can reset it by starting the service and choosing ‘Don't remember your password?’ from the sign in screen.
+
+    %p
+      If you are unable to sign in or do not receive a password reset email from the service, contact
       = succeed '.' do
-        If you are unable to sign in or have not received any email from us, please contact support at
-        = mail_to support_email_address
-    %p
-      = link_to 'Sign in', '/auth/auth0'
-      to get the template for your framework(s) and to report your management information.
+        = mail_to(support_email_address, nil)
 
-    = link_to 'Sign in', '/auth/auth0', class: 'govuk-button', id: 'sign-in'
+    %h3.govuk-heading-s
+      Check which service to report to
+    %p
+      Check the lists of frameworks that should be submitted through this service:
 
     %p
-      If you didn’t do any business, you still need to sign in and let us know.
+      = link_to('List of frameworks submitted through this service', '/support/frameworks')
+
+    %p
+      For frameworks not listed, use the existing MISO service:
+
+    %p
+      = link_to('https://miso.ccs.cabinetoffice.gov.uk/', 'https://miso.ccs.cabinetoffice.gov.uk/')
+
+
+    %p
+      If you are unsure about which service to use, contact
+      %br
+      = succeed '.' do
+        = mail_to(support_email_address, nil)

--- a/app/views/support/frameworks.html.haml
+++ b/app/views/support/frameworks.html.haml
@@ -1,0 +1,94 @@
+.govuk-grid-row
+  .govuk-grid-column-full
+    %h1.govuk-heading-xl
+      Check which service to report to
+.govuk-grid-row
+  .govuk-grid-column-two-thirds
+    %p
+      The following frameworks are submitted throught this service.
+    %p
+      If you are reporting on any other framework, use the existing
+      %a{ :href => 'https://miso.ccs.cabinetoffice.gov.uk/', :title => 'Link to MISO Service' }
+        MISO service
+.govuk-grid-row
+  .govuk-grid-column-full
+    = link_to('Back', '/',{ :class => 'govuk-back-link', :title => 'Link to start page'})
+    %table.govuk-table
+      %thead.govuk-table__head
+        %tr.govuk-table__row
+          %th.govuk-table__header{ :scope => 'col'}
+            Framework number
+          %th.govuk-table__header{ :scope => 'col'}
+            Framework name
+      %tbody.govuk-table__body
+        %tr.govuk-table__row
+          %td.govuk-table__cell
+            CM/OSG/05/3565
+          %td.govuk-table__cell
+            Laundry Services Wave 2
+        %tr.govuk-table__row
+          %td.govuk-table__cell
+            RM807
+          %td.govuk-table__cell
+            Vehicle Hire
+        %tr.govuk-table__row
+          %td.govuk-table__cell
+            RM849
+          %td.govuk-table__cell
+            Laundry and Linen Services
+        %tr.govuk-table__row
+          %td.govuk-table__cell
+            RM858
+          %td.govuk-table__cell
+            Pan Government Vehicle Leasing and Fleet Outsource Solutions
+        %tr.govuk-table__row
+          %td.govuk-table__cell
+            RM1031
+          %td.govuk-table__cell
+            Laundry and Linen Services
+        %tr.govuk-table__row
+          %td.govuk-table__cell
+            RM1070
+          %td.govuk-table__cell
+            Vehicle Purchase
+        %tr.govuk-table__row
+          %td.govuk-table__cell
+            RM3710
+          %td.govuk-table__cell
+            Vehicle Lease and Fleet Management
+        %tr.govuk-table__row
+          %td.govuk-table__cell
+            RM3754
+          %td.govuk-table__cell
+            Vehicle Telematics
+        %tr.govuk-table__row
+          %td.govuk-table__cell
+            RM3756
+          %td.govuk-table__cell
+            Rail Legal Services
+        %tr.govuk-table__row
+          %td.govuk-table__cell
+            RM3767
+          %td.govuk-table__cell
+            Supply and Fit of Tyres
+        %tr.govuk-table__row
+          %td.govuk-table__cell
+            RM3772
+          %td.govuk-table__cell
+            Specialist Laundry Services
+        %tr.govuk-table__row
+          %td.govuk-table__cell
+            RM3786
+          %td.govuk-table__cell
+            General Legal Services
+        %tr.govuk-table__row
+          %td.govuk-table__cell
+            RM3787
+          %td.govuk-table__cell
+            Finance & Complex Legal Services
+        %tr.govuk-table__row
+          %td.govuk-table__cell
+            RM3797
+          %td.govuk-table__cell
+            Journal Subscriptions
+    = link_to('Back', '/',{ :class => 'govuk-back-link', :title => 'Link to start page'})

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,4 +17,5 @@ Rails.application.routes.draw do
   get '/style_guide', to: 'styleguide#index'
   get '/urns', to: 'urns#index'
   get '/support', to: 'support#index'
+  get '/support/frameworks', to: 'support#frameworks'
 end

--- a/spec/features/task_management_spec.rb
+++ b/spec/features/task_management_spec.rb
@@ -9,7 +9,7 @@ RSpec.feature 'task management' do
     mock_upload_task_submission_flow_endpoints!
 
     visit '/'
-    click_link 'sign-in'
+    click_link 'start-now'
 
     visit '/tasks'
 
@@ -44,7 +44,7 @@ RSpec.feature 'task management' do
     mock_submission_errored_endpoint!
 
     visit '/'
-    click_link 'sign-in'
+    click_link 'start-now'
 
     visit task_submission_path(task_id: mock_task_id, id: mock_submission_id)
 

--- a/spec/features/user_can_submit_no_business_spec.rb
+++ b/spec/features/user_can_submit_no_business_spec.rb
@@ -11,7 +11,7 @@ RSpec.feature 'Submitting no business' do
     mock_submission_completed_endpoint!
 
     visit '/'
-    click_link 'sign-in'
+    click_link 'start-now'
 
     visit '/tasks'
 

--- a/spec/features/users_can_sign_in_spec.rb
+++ b/spec/features/users_can_sign_in_spec.rb
@@ -7,7 +7,7 @@ RSpec.feature 'Signing in as a user' do
 
     visit '/tasks'
 
-    click_on 'sign-in'
+    click_on 'start-now'
 
     expect(page).to have_content 'Sign out'
   end
@@ -17,7 +17,7 @@ RSpec.feature 'Signing in as a user' do
     mock_tasks_endpoint!
 
     visit '/'
-    click_on 'sign-in'
+    click_on 'start-now'
 
     visit '/'
     click_on 'Sign out'

--- a/spec/features/users_can_upload_completed_spreadsheet_spec.rb
+++ b/spec/features/users_can_upload_completed_spreadsheet_spec.rb
@@ -11,7 +11,7 @@ RSpec.feature 'User uploads completed spreadsheet' do
       mock_sso_with(email: 'email@example.com')
 
       visit '/'
-      click_link 'sign-in'
+      click_link 'start-now'
 
       visit '/tasks'
       click_on 'Report management information'
@@ -28,7 +28,7 @@ RSpec.feature 'User uploads completed spreadsheet' do
       mock_sso_with(email: 'email@example.com')
 
       visit '/'
-      click_link 'sign-in'
+      click_link 'start-now'
 
       visit '/tasks'
       click_on 'Report management information'
@@ -45,7 +45,7 @@ RSpec.feature 'User uploads completed spreadsheet' do
       mock_sso_with(email: 'email@example.com')
 
       visit '/'
-      click_link 'sign-in'
+      click_link 'start-now'
 
       visit '/tasks'
       click_on 'Report management information'
@@ -62,7 +62,7 @@ RSpec.feature 'User uploads completed spreadsheet' do
       mock_sso_with(email: 'email@example.com')
 
       visit '/'
-      click_link 'sign-in'
+      click_link 'start-now'
 
       visit '/tasks'
       click_on 'Report management information'

--- a/spec/requests/support_spec.rb
+++ b/spec/requests/support_spec.rb
@@ -6,6 +6,6 @@ RSpec.describe 'the support page' do
 
     expect(response).to be_successful
     expect(response.body).to include('Support')
-    expect(response.body).to include('dss@crowncommercial.gov.uk')
+    expect(response.body).to include('report-mi@crowncommercial.gov.uk')
   end
 end


### PR DESCRIPTION
We currently show the user which frameworks are submitted through
the new service on the start view. As the number of frameworks grows
this approach was not sustainable.

We decided to add a separate page that lists the frameworks as a interim
solution to this problem with a view to something longer term later.

This change also meant re-wording the content on the start page and
switching to the GOVUK start page pattern which includes the 'start now'
button.

We also took this opportunity to update the support email address which
changed to report-mi@ inline with the service name.

To achieve this we:

- added the back link component
- added a new view to the support controller
- changed the support email address in the helper method
- changed all the content on the start page
- added the framework list view
- added the route to render the view
- updated the tests to reflect these changes

Fixes:
https://trello.com/c/xoKcqVhq