### PR TITLE
Fix sporadically failing spec

### DIFF
--- a/spec/models/api/task_spec.rb
+++ b/spec/models/api/task_spec.rb
@@ -35,8 +35,8 @@ RSpec.describe API::Task do
 
   describe '#late?' do
     it 'returns true if the due date has passed' do
-      expect(API::Task.new(due_on: '2018-08-07')).to be_late
-      expect(API::Task.new(due_on: '2030-08-07')).not_to be_late
+      expect(API::Task.new(status: 'in_progress', due_on: '2018-08-07')).to be_late
+      expect(API::Task.new(status: 'in_progress', due_on: '2030-08-07')).not_to be_late
     end
 
     it 'returns false for a completed task' do


### PR DESCRIPTION
```
  $ rspec --seed 8321

  Randomized with seed 8321
  F......................................................

  Failures:

    1) API::Task#late? returns true if the due date has passed
       Failure/Error: status == 'completed'

       NameError:
         undefined local variable or method `status' for #<API::Task:0x00007f94109019a0>
       # /Users/tekin/.gem/ruby/2.5.1/gems/jsonapi-consumer-1.0.1/lib/jsonapi/consumer/helpers/dynamic_attributes.rb:55:in `method_missing'
       # /Users/tekin/.gem/ruby/2.5.1/gems/jsonapi-consumer-1.0.1/lib/jsonapi/consumer/helpers/dirty.rb:60:in `method_missing'
       # /Users/tekin/.gem/ruby/2.5.1/gems/jsonapi-consumer-1.0.1/lib/jsonapi/consumer/resource.rb:485:in `method_missing'
       # ./app/models/api/task.rb:9:in `complete?'
       # ./app/models/api/task.rb:17:in `late?'
       # ./spec/models/api/task_spec.rb:38:in `block (3 levels) in <main>'
```

It's not clear why this spec would fail sporadically as the internals of
jsonapi-consumer suggest that the instance would only respond to the
`status` method if it was present as an attribute on initialisation.
Either way, it's better for the spec for the status to be explicitly
stated.