### PR TITLE
Send User's Auth ID in API requests

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -1,7 +1,7 @@
 class TasksController < ApplicationController
   def index
     tasks = API::Task
-            .where(user_id: current_user.id)
+            .where(user_id: current_user.id, auth_id: current_user.uid)
             .includes(:framework, :latest_submission)
             .all
             .sort_by! { |t| Date.parse(t.due_on) }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,7 +16,7 @@
 
 # Stub external HTTP requests
 require 'webmock/rspec'
-WebMock.disable_net_connect!(allow_localhost: true)
+WebMock.disable_net_connect!
 
 RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate

--- a/spec/support/api_helpers.rb
+++ b/spec/support/api_helpers.rb
@@ -110,13 +110,13 @@ module ApiHelpers
 
   def mock_tasks_endpoint!
     stub_request(:get, api_url('tasks'))
-      .with(query: hash_including({}))
+      .with(query: hash_including(filter: hash_including('user_id', 'auth_id')))
       .to_return(headers: json_headers, body: json_fixture_file('tasks_with_framework_and_latest_submission.json'))
   end
 
   def mock_empty_tasks_endpoint!
     stub_request(:get, api_url('tasks'))
-      .with(query: hash_including({}))
+      .with(query: hash_including(filter: hash_including('user_id', 'auth_id')))
       .to_return(headers: json_headers, body: '{}')
   end
 


### PR DESCRIPTION
As part of removing the user model from this app, we will need to start sending the AuthID (to come straight from Auth0 in the future) to the API.

Also stop allowing real localhost connections in specs, because I don't know why we were, and was making it harder to debug.