### PR TITLE
Add basic authentication to API

### DIFF
--- a/app/models/api/base.rb
+++ b/app/models/api/base.rb
@@ -1,5 +1,8 @@
 module API
   class Base < JSONAPI::Consumer::Resource
     self.site = ENV['API_ROOT'] + 'v1/'
+    connection do |conn|
+      conn.use Faraday::Request::BasicAuthentication, 'dxw', ENV['API_PASSWORD'] if ENV['API_PASSWORD']
+    end
   end
 end


### PR DESCRIPTION
As part of opening up the API application to public IPs, we want to add basic authentication to API methods as a backstop should the infrastructure accidentally fail to block requests to it.