### PR TITLE
(573) Update the the confirmation page

### DIFF
--- a/app/views/submissions/completed.html.haml
+++ b/app/views/submissions/completed.html.haml
@@ -2,12 +2,23 @@
   .govuk-grid-column-two-thirds
     .govuk-panel.govuk-panel--confirmation
       %h1.govuk-panel__title
-        = @task.description
-        Management information for
-        = @task.framework.short_name
-        = @task.framework.name
-        submitted to CCS
-
+        Task complete
+      .govuk-panel__body
+        - if @submission.report_no_business?
+          Thank you for reporting no business for
+        - else
+          Thank you for reporting your management information for
+        = @task.period_month_name
+        = @task.period_year
+    %h3.govuk-heading-s
+      Framework
+    %p
+      = @task.framework.short_name
+      = @task.framework.name
+    %h2.govuk-heading-m
+      What happens next
+    %p
+      We will contact you if we need more information about what you have told us.
     %p
       If you’ve made a mistake or need to amend the management information
       you've supplied, email

--- a/spec/features/task_management_spec.rb
+++ b/spec/features/task_management_spec.rb
@@ -31,11 +31,11 @@ RSpec.feature 'task management' do
 
     mock_complete_submission_endpoint!
     mock_submission_completed_with_task_endpoint!
-    mock_submission_completed_endpoint!
+    mock_submission_completed_report_mi_endpoint!
 
     click_on 'Submit management information'
 
-    expect(page).to have_content 'submitted to CCS'
+    expect(page).to have_content 'Thank you for reporting your management information for'
   end
 
   scenario 'user can upload an amended file' do

--- a/spec/features/user_can_submit_no_business_spec.rb
+++ b/spec/features/user_can_submit_no_business_spec.rb
@@ -8,7 +8,7 @@ RSpec.feature 'Submitting no business' do
     mock_tasks_endpoint!
     mock_task_with_framework_endpoint!
     mock_no_business_endpoint!
-    mock_submission_completed_endpoint!
+    mock_submission_completed_no_business_endpoint!
 
     visit '/'
     click_link 'start-now'
@@ -23,6 +23,6 @@ RSpec.feature 'Submitting no business' do
 
     click_on 'Confirm'
 
-    expect(page).to have_content 'submitted to CCS'
+    expect(page).to have_content 'Thank you for reporting no business for'
   end
 end

--- a/spec/fixtures/mocks/submission_completed_no_business.json
+++ b/spec/fixtures/mocks/submission_completed_no_business.json
@@ -1,0 +1,16 @@
+{
+  "data": {
+    "id": "9a5ef62c-0781-4f80-8850-5793652b6b40",
+    "type": "submissions",
+    "attributes": {
+      "framework_id": "f87717d4-874a-43d9-b99f-c8cf2897b526",
+      "supplier_id": "cd40ead8-67b5-4918-abf0-ab8937cd04ff",
+      "invoice_count": 0,
+      "order_count": 0,
+      "purchase_order_number": null,
+      "status": "completed",
+      "levy": 0,
+      "report_no_business?": true
+    }
+  }
+}

--- a/spec/fixtures/mocks/submission_completed_report_mi.json
+++ b/spec/fixtures/mocks/submission_completed_report_mi.json
@@ -9,7 +9,8 @@
       "order_count": 1,
       "purchase_order_number": null,
       "status": "completed",
-      "levy": 4500
+      "levy": 4500,
+      "report_no_business?": false
     }
   }
 }

--- a/spec/requests/submissions_spec.rb
+++ b/spec/requests/submissions_spec.rb
@@ -50,11 +50,11 @@ RSpec.describe 'the submission page' do
     end
 
     it 'shows completed submission page for a "completed" submission' do
-      mock_submission_completed_endpoint!
+      mock_submission_completed_no_business_endpoint!
       get task_submission_path(task_id: mock_task_id, id: mock_submission_id)
 
       expect(response).to be_successful
-      expect(response.body).to include 'submitted to CCS'
+      expect(response.body).to include 'Thank you for reporting no business for'
     end
   end
 end

--- a/spec/support/api_helpers.rb
+++ b/spec/support/api_helpers.rb
@@ -45,9 +45,14 @@ module ApiHelpers
       .to_return(headers: json_headers, body: json_fixture_file('submission_errored.json'))
   end
 
-  def mock_submission_completed_endpoint!
+  def mock_submission_completed_no_business_endpoint!
     stub_request(:get, api_url("submissions/#{mock_submission_id}"))
-      .to_return(headers: json_headers, body: json_fixture_file('submission_completed.json'))
+      .to_return(headers: json_headers, body: json_fixture_file('submission_completed_no_business.json'))
+  end
+
+  def mock_submission_completed_report_mi_endpoint!
+    stub_request(:get, api_url("submissions/#{mock_submission_id}"))
+      .to_return(headers: json_headers, body: json_fixture_file('submission_completed_report_mi.json'))
   end
 
   def mock_submission_completed_with_task_endpoint!


### PR DESCRIPTION
Added a way to check that a user is reporting no business or MI.
We introduced a report_no_business? check based on the number of
submission files.

The confirmation page now reflects this change along with new content.

https://trello.com/c/asjZO0fu/596-frontend-confirmation-page-iteration