### PR TITLE
(613) All pages should have descriptive titles

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -10,4 +10,8 @@ module ApplicationHelper
   def task_due_date(task)
     task.due_on.to_date
   end
+
+  def page_title(title)
+    content_for :page_title, title
+  end
 end

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -2,7 +2,8 @@
 %html{ lang: 'en-GB', class: 'govuk-template' }
   %head
     %meta{ content: 'text/html; charset=UTF-8', 'http-equiv': 'Content-Type' }/
-    %title Report management information to CCS
+    %title
+      = yield(:page_title) || 'Report management information to CCS'
 
     %meta{ name: 'viewport', content: 'width=device-width, initial-scale=1' }/
     %meta{ 'http-equiv': 'x-ua-compatible', content: 'ie-edge' }/

--- a/app/views/no_businesses/new.html.haml
+++ b/app/views/no_businesses/new.html.haml
@@ -1,3 +1,5 @@
+- page_title "Confirm report no business for #{@task.period_month_name} on #{@task.framework.short_name}"
+
 .govuk-grid-row
   .govuk-grid-column-full
     = render 'shared/task_signpost', task: @task, action: 'Report no business for'

--- a/app/views/submissions/completed.html.haml
+++ b/app/views/submissions/completed.html.haml
@@ -1,3 +1,8 @@
+- if @submission.report_no_business?
+  - page_title "Task complete: Report no business for #{@task.period_month_name} on #{@task.framework.short_name} "
+- else
+  - page_title "Task complete: Report management information for #{@task.period_month_name} on #{@task.framework.short_name}"
+
 .govuk-grid-row
   .govuk-grid-column-two-thirds
     .govuk-panel.govuk-panel--confirmation
@@ -26,7 +31,7 @@
       We will contact you if we need more information about what you have told us.
     %p
       If you’ve made a mistake or need to amend the management information
-      you've supplied, email
+      you’ve supplied, email
       = mail_to(support_email_address)
       for help.
     %p

--- a/app/views/submissions/in_review.html.haml
+++ b/app/views/submissions/in_review.html.haml
@@ -1,3 +1,5 @@
+- page_title "Review & submit: Report management information for #{@task.period_month_name} on #{@task.framework.short_name}"
+
 .govuk-grid-row
   .govuk-grid-column-full
     = render 'shared/task_signpost', task: @task

--- a/app/views/submissions/new.html.haml
+++ b/app/views/submissions/new.html.haml
@@ -1,3 +1,5 @@
+- page_title "Report management information for #{@task.period_month_name} on #{@task.framework.short_name}"
+
 .govuk-grid-row
   .govuk-grid-column-full
     = render 'shared/task_signpost', task: @task

--- a/app/views/submissions/processing.html.haml
+++ b/app/views/submissions/processing.html.haml
@@ -1,3 +1,5 @@
+- page_title "Checking file: Report management information for #{@task.period_month_name} on #{@task.framework.short_name}"
+
 = content_for(:head, tag.meta('http-equiv': 'refresh', content: 5))
 
 .govuk-grid-row

--- a/app/views/submissions/validation_failed.html.haml
+++ b/app/views/submissions/validation_failed.html.haml
@@ -1,3 +1,5 @@
+- page_title "Errors to correct: Report management information for #{@task.period_month_name} on #{@task.framework.short_name}"
+
 .govuk-grid-row
   .govuk-grid-column-full
     = render 'shared/task_signpost', task: @task

--- a/app/views/support/index.html.haml
+++ b/app/views/support/index.html.haml
@@ -1,3 +1,5 @@
+- page_title 'Support'
+
 .govuk-grid-row
   .govuk-grid-column-full
     %h1.govuk-heading-xl
@@ -31,7 +33,7 @@
         If you can, include screenshots of any error screens or messages.
     %p
       If you’ve made a mistake or need to amend the management information
-      you've supplied, email
+      you’ve supplied, email
       = mail_to support_email_address
       for help.
     %p

--- a/app/views/tasks/index.html.haml
+++ b/app/views/tasks/index.html.haml
@@ -1,3 +1,5 @@
+- page_title 'Your reporting tasks'
+
 .govuk-grid-row
   .govuk-grid-column-full
     %h1.govuk-heading-xl

--- a/app/views/urns/index.html.haml
+++ b/app/views/urns/index.html.haml
@@ -1,3 +1,5 @@
+- page_title 'Unique reference number lookup'
+
 .govuk-grid-row
   .govuk-grid-column-full
     %h1.govuk-heading-xl


### PR DESCRIPTION
- Adds a page title region to the application layout
- Adds a helper to set the page title or use a default of 'Report management information to CCS'
- Adds custom page titles to pages in the submission process using the month and RM#
- Changes two apostrophises