### PR TITLE
Feature/617 Accessibility issues with the start page

### DIFF
--- a/app/views/home/guest_homepage.html.haml
+++ b/app/views/home/guest_homepage.html.haml
@@ -21,7 +21,7 @@
       If you didn’t do any business, you still need to sign in and let us know.
 
     %h2.govuk-heading-m
-      Before you Sign in
+      Before you sign in
 
     %h3.govuk-heading-s
       Your account
@@ -66,4 +66,4 @@
 
     %p
       %br
-      = link_to 'Sign in', '/auth/auth0', class: 'govuk-button govuk-button--start', id: 'start-now', 'aria-label' => "Sign in to the service"
+      = link_to 'Sign in', '/auth/auth0', class: 'govuk-button govuk-button--start', id: 'sign-in', 'aria-label' => "Sign in to the service"

--- a/app/views/home/guest_homepage.html.haml
+++ b/app/views/home/guest_homepage.html.haml
@@ -12,17 +12,16 @@
       %li
         get the template for your framework(s)
       %li
-        report your management information to CCS for
-        = link_to('certain frameworks', '/support/frameworks')
+        report your management information to CCS for a
+        = link_to('selection of frameworks', '/support/frameworks', 'aria-label' => "List of frameworks reporting management information to CCS")
+
       %li
         report no business to CCS
     %p
       If you didn’t do any business, you still need to sign in and let us know.
 
-    = link_to 'Start now', '/auth/auth0', class: 'govuk-button govuk-button--start', id: 'start-now'
-
     %h2.govuk-heading-m
-      Before you start
+      Before you Sign in
 
     %h3.govuk-heading-s
       Your account
@@ -37,27 +36,34 @@
       If you don’t know or have forgotten your password you can reset it by starting the service and choosing ‘Don't remember your password?’ from the sign in screen.
 
     %p
-      If you are unable to sign in or do not receive a password reset email from the service, contact
+      If you are unable to sign in or do not receive a password reset email from the service contact report-mi@crowncommercial.gov.uk. 
+      %br
       = succeed '.' do
-        = mail_to(support_email_address, nil)
+        = mail_to(support_email_address, 'Email sign in support')
 
     %h3.govuk-heading-s
       Check which service to report to
     %p
-      Check the lists of frameworks that should be submitted through this service:
-
-    %p
-      = link_to('List of frameworks submitted through this service', '/support/frameworks')
-
-    %p
-      For frameworks not listed, use the existing MISO service:
-
-    %p
-      = link_to('https://miso.ccs.cabinetoffice.gov.uk/', 'https://miso.ccs.cabinetoffice.gov.uk/')
-
-
-    %p
-      If you are unsure about which service to use, contact
+      Check the lists of frameworks that should be submitted through this service: 
       %br
       = succeed '.' do
-        = mail_to(support_email_address, nil)
+        = link_to('List of frameworks submitted through this service', '/support/frameworks')
+
+    %p
+      For frameworks not listed, use the existing MISO service: 
+      %br
+      = succeed '.' do
+        = link_to('MISO service for frameworks not listed', 'https://miso.ccs.cabinetoffice.gov.uk/')
+
+
+    %p
+      If you are unsure about which service to use email 
+      %br
+      report-mi@crowncommercial.gov.uk.
+      %br
+      = succeed '.' do
+        = mail_to(support_email_address, 'Email service support')
+
+    %p
+      %br
+      = link_to 'Sign in', '/auth/auth0', class: 'govuk-button govuk-button--start', id: 'start-now', 'aria-label' => "Sign in to the service"

--- a/spec/features/task_management_spec.rb
+++ b/spec/features/task_management_spec.rb
@@ -10,7 +10,7 @@ RSpec.feature 'task management' do
     mock_user_endpoint!
 
     visit '/'
-    click_link 'start-now'
+    click_link 'sign-in'
 
     visit '/tasks'
 
@@ -47,7 +47,7 @@ RSpec.feature 'task management' do
     mock_submission_errored_endpoint!
 
     visit '/'
-    click_link 'start-now'
+    click_link 'sign-in'
 
     visit task_submission_path(task_id: mock_task_id, id: mock_submission_id)
 
@@ -67,7 +67,7 @@ RSpec.feature 'task management' do
     mock_user_with_multiple_suppliers_endpoint!
 
     visit '/'
-    click_link 'start-now'
+    click_link 'sign-in'
 
     visit '/tasks'
 

--- a/spec/features/user_can_submit_no_business_spec.rb
+++ b/spec/features/user_can_submit_no_business_spec.rb
@@ -12,7 +12,7 @@ RSpec.feature 'Submitting no business' do
     mock_user_endpoint!
 
     visit '/'
-    click_link 'start-now'
+    click_link 'sign-in'
 
     visit '/tasks'
 
@@ -39,7 +39,7 @@ RSpec.feature 'Submitting no business' do
     mock_user_with_multiple_suppliers_endpoint!
 
     visit '/'
-    click_link 'start-now'
+    click_link 'sign-in'
 
     visit '/tasks'
 

--- a/spec/features/users_can_sign_in_spec.rb
+++ b/spec/features/users_can_sign_in_spec.rb
@@ -8,7 +8,7 @@ RSpec.feature 'Signing in as a user' do
 
     visit '/tasks'
 
-    click_on 'start-now'
+    click_on 'sign-in'
 
     expect(page).to have_content 'Sign out'
   end
@@ -19,7 +19,7 @@ RSpec.feature 'Signing in as a user' do
     mock_user_endpoint!
 
     visit '/'
-    click_on 'start-now'
+    click_on 'sign-in'
 
     visit '/'
     click_on 'Sign out'

--- a/spec/features/users_can_upload_completed_spreadsheet_spec.rb
+++ b/spec/features/users_can_upload_completed_spreadsheet_spec.rb
@@ -12,7 +12,7 @@ RSpec.feature 'User uploads completed spreadsheet' do
       mock_sso_with(email: 'email@example.com')
 
       visit '/'
-      click_link 'start-now'
+      click_link 'sign-in'
 
       visit '/tasks'
       click_on 'Report management information'
@@ -30,7 +30,7 @@ RSpec.feature 'User uploads completed spreadsheet' do
       mock_user_endpoint!
 
       visit '/'
-      click_link 'start-now'
+      click_link 'sign-in'
 
       visit '/tasks'
       click_on 'Report management information'
@@ -52,7 +52,7 @@ RSpec.feature 'User uploads completed spreadsheet' do
       mock_user_with_multiple_suppliers_endpoint!
 
       visit '/'
-      click_link 'start-now'
+      click_link 'sign-in'
 
       visit '/tasks'
 
@@ -77,7 +77,7 @@ RSpec.feature 'User uploads completed spreadsheet' do
       mock_user_endpoint!
 
       visit '/'
-      click_link 'start-now'
+      click_link 'sign-in'
 
       visit '/tasks'
       click_on 'Report management information'
@@ -95,7 +95,7 @@ RSpec.feature 'User uploads completed spreadsheet' do
       mock_user_endpoint!
 
       visit '/'
-      click_link 'start-now'
+      click_link 'sign-in'
 
       visit '/tasks'
       click_on 'Report management information'
@@ -116,7 +116,7 @@ RSpec.feature 'User uploads completed spreadsheet' do
       mock_user_with_multiple_suppliers_endpoint!
 
       visit '/'
-      click_link 'start-now'
+      click_link 'sign-in'
 
       visit '/tasks/2d98639e-5260-411f-a5ee-61847a2e067c/submissions/9a5ef62c-0781-4f80-8850-5793652b6b40'
 
@@ -135,7 +135,7 @@ RSpec.feature 'User uploads completed spreadsheet' do
       mock_complete_submission_endpoint!
 
       visit '/'
-      click_link 'start-now'
+      click_link 'sign-in'
 
       visit '/tasks/2d98639e-5260-411f-a5ee-61847a2e067c/submissions/9a5ef62c-0781-4f80-8850-5793652b6b40'
 

--- a/spec/requests/home_spec.rb
+++ b/spec/requests/home_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'the home page' do
   it 'shows introductory text for non-signed in users' do
     get root_path
 
-    expect(response.body).to include 'Before you start'
+    expect(response.body).to include 'Before you sign in'
   end
 
   it 'links to the user’s task list when signed in' do


### PR DESCRIPTION
**The problem**
Feedback from DAC report
1. While navigating the Start page, visually impaired users said the 'Before you start' information should be before the start now button. This is to give users context or help before the call to action it relates to.
2. Links on the page: is not descriptive enough of its destination for screen reader users to understand when navigating out of context.

Even though we are following the gov design system on the start page, there is controversy regarding accessibility please see discussion in [GitHub gov start page](https://github.com/alphagov/govuk-design-system-backlog/issues/111)

**Changes made to the PR**

1. 'Before you start' is moved above the start button.
2. 'Start now' is updated as 'Sign in' as this is what it really represents.
4. I have reworded the links of the page to contain descriptive context