### PR TITLE
Release 27

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## [release-26] - 2018-12-17
+
+- Add skylight
+
 ## [release-25] - 2018-12-12
 
 - Added DOS3 framework template file
@@ -147,6 +151,7 @@
 
 Initial release
 
+[release-26]: https://github.com/dxw/DataSubmissionService/compare/release-25...release-26
 [release-25]: https://github.com/dxw/DataSubmissionService/compare/release-24...release-25
 [release-24]: https://github.com/dxw/DataSubmissionService/compare/release-23...release-24
 [release-23]: https://github.com/dxw/DataSubmissionService/compare/release-22...release-23

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## [release-27] - 2018-12-19
+
+- RM1043.5 added to list of frameworks supported on RMI
+- Corrected typo on frameworks page
+
 ## [release-26] - 2018-12-17
 
 - Add skylight
@@ -151,6 +156,7 @@
 
 Initial release
 
+[release-27]: https://github.com/dxw/DataSubmissionService/compare/release-26...release-27
 [release-26]: https://github.com/dxw/DataSubmissionService/compare/release-25...release-26
 [release-25]: https://github.com/dxw/DataSubmissionService/compare/release-24...release-25
 [release-24]: https://github.com/dxw/DataSubmissionService/compare/release-23...release-24


### PR DESCRIPTION
Includes the release note changes for release 26, which weren't merged at the time.

- RM1043.5 added to list of frameworks supported on RMI
- Corrected typo on frameworks page