### PR TITLE
(642) Always include current user's 'auth_id' parameter in API requests

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,5 @@
 class ApplicationController < ActionController::Base
+  before_action :set_current_request_details
   before_action :ensure_user_signed_in
 
   helper_method :current_user_id
@@ -19,5 +20,9 @@ class ApplicationController < ActionController::Base
     return if current_user_id.present?
 
     redirect_to root_path
+  end
+
+  def set_current_request_details
+    Current.auth_id = session[:auth_id]
   end
 end

--- a/app/models/api/base.rb
+++ b/app/models/api/base.rb
@@ -1,7 +1,16 @@
 module API
   class Base < JSONAPI::Consumer::Resource
     self.site = ENV['API_ROOT'] + 'v1/'
+
+    class IncludeAuthId < Faraday::Middleware
+      def call(env)
+        env[:request_headers]['X-Auth-Id'] = Current.auth_id
+        @app.call(env)
+      end
+    end
+
     connection do |conn|
+      conn.use IncludeAuthId
       conn.use Faraday::Request::BasicAuthentication, 'dxw', ENV['API_PASSWORD'] if ENV['API_PASSWORD']
     end
   end

--- a/app/models/current.rb
+++ b/app/models/current.rb
@@ -1,0 +1,3 @@
+class Current < ActiveSupport::CurrentAttributes
+  attribute :auth_id
+end

--- a/spec/models/api/base_spec.rb
+++ b/spec/models/api/base_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.describe API::Base do
+  let(:dummy_api_model) do
+    Class.new(API::Base) do
+      # Boilerplate
+      def self.name
+        'dummy'
+      end
+    end
+  end
+
+  it 'includes the X-Auth-Id header in every request' do
+    allow(Current).to receive(:auth_id).and_return('fake-auth-id')
+
+    stub_request(:get, 'https://ccs.api/v1/dummies/1234')
+
+    dummy_api_model.find('1234')
+
+    expect(
+      a_request(:get, 'https://ccs.api/v1/dummies/1234')
+      .with(headers: { 'X-Auth-Id': 'fake-auth-id' })
+    ).to have_been_made
+  end
+end

--- a/spec/support/api_helpers.rb
+++ b/spec/support/api_helpers.rb
@@ -197,7 +197,10 @@ module ApiHelpers
   private
 
   def json_headers
-    { 'Content-Type': 'application/vnd.api+json; charset=utf-8' }
+    {
+      'Content-Type': 'application/vnd.api+json; charset=utf-8',
+      'X-Auth-Id': '123456'
+    }
   end
 
   def json_fixture_file(filename)


### PR DESCRIPTION
Uses [ActiveSupport::CurrentAttributes](https://api.rubyonrails.org/classes/ActiveSupport/CurrentAttributes.html) to allow a model to access the `auth_id` session variable, which is usually only available from controllers.

Thanks @tekin :)