### PR TITLE
Include year when showing task reporting period

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ COPY Gemfile.lock $INSTALL_PATH/Gemfile.lock
 COPY package.json yarn.lock $INSTALL_PATH/
 
 RUN yarn
-
+RUN gem update --system 3.0.0
 RUN gem install bundler
 
 # bundle ruby gems based on the current environment, default to production

--- a/app/controllers/templates_controller.rb
+++ b/app/controllers/templates_controller.rb
@@ -8,6 +8,6 @@ class TemplatesController < ApplicationController
   private
 
   def template_filename_for_task_period(task)
-    "#{task.framework.safe_short_name} Data Template (#{task.period_month_name} #{task.period_year}).xls"
+    "#{task.framework.safe_short_name} Data Template (#{task.reporting_period}).xls"
   end
 end

--- a/app/models/api/task.rb
+++ b/app/models/api/task.rb
@@ -17,8 +17,8 @@ module API
       !complete? && due_on.to_date < Time.zone.today
     end
 
-    def period_month_name
-      Date::MONTHNAMES[period_month]
+    def reporting_period
+      [Date::MONTHNAMES[period_month], period_year].join(' ')
     end
   end
 end

--- a/app/views/no_businesses/new.html.haml
+++ b/app/views/no_businesses/new.html.haml
@@ -1,4 +1,4 @@
-- page_title "Confirm report no business for #{@task.period_month_name} on #{@task.framework.short_name}"
+- page_title "Confirm report no business for #{@task.reporting_period} on #{@task.framework.short_name}"
 
 .govuk-grid-row
   .govuk-grid-column-full

--- a/app/views/submissions/completed.html.haml
+++ b/app/views/submissions/completed.html.haml
@@ -1,7 +1,7 @@
 - if @submission.report_no_business?
-  - page_title "Task complete: Report no business for #{@task.period_month_name} on #{@task.framework.short_name} "
+  - page_title "Task complete: Report no business for #{@task.reporting_period} on #{@task.framework.short_name} "
 - else
-  - page_title "Task complete: Report management information for #{@task.period_month_name} on #{@task.framework.short_name}"
+  - page_title "Task complete: Report management information for #{@task.reporting_period} on #{@task.framework.short_name}"
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds
@@ -13,8 +13,7 @@
           Thank you for reporting no business for
         - else
           Thank you for reporting your management information for
-        = @task.period_month_name
-        = @task.period_year
+        = @task.reporting_period
     - if current_user.multiple_suppliers?
       %h3.govuk-heading-s
         Supplier

--- a/app/views/submissions/in_review.html.haml
+++ b/app/views/submissions/in_review.html.haml
@@ -1,4 +1,4 @@
-- page_title "Review & submit: Report management information for #{@task.period_month_name} on #{@task.framework.short_name}"
+- page_title "Review & submit: Report management information for #{@task.reporting_period} on #{@task.framework.short_name}"
 
 .govuk-grid-row
   .govuk-grid-column-full

--- a/app/views/submissions/new.html.haml
+++ b/app/views/submissions/new.html.haml
@@ -1,4 +1,4 @@
-- page_title "Report management information for #{@task.period_month_name} on #{@task.framework.short_name}"
+- page_title "Report management information for #{@task.reporting_period} on #{@task.framework.short_name}"
 
 .govuk-grid-row
   .govuk-grid-column-full

--- a/app/views/submissions/processing.html.haml
+++ b/app/views/submissions/processing.html.haml
@@ -1,4 +1,4 @@
-- page_title "Checking file: Report management information for #{@task.period_month_name} on #{@task.framework.short_name}"
+- page_title "Checking file: Report management information for #{@task.reporting_period} on #{@task.framework.short_name}"
 
 = content_for(:head, tag.meta('http-equiv': 'refresh', content: 5))
 

--- a/app/views/submissions/validation_failed.html.haml
+++ b/app/views/submissions/validation_failed.html.haml
@@ -1,4 +1,4 @@
-- page_title "Errors to correct: Report management information for #{@task.period_month_name} on #{@task.framework.short_name}"
+- page_title "Errors to correct: Report management information for #{@task.reporting_period} on #{@task.framework.short_name}"
 
 .govuk-grid-row
   .govuk-grid-column-full

--- a/app/views/tasks/_task.html.haml
+++ b/app/views/tasks/_task.html.haml
@@ -10,7 +10,7 @@
     .ccs-task__body
       %h2.govuk-heading-s
         Report management information for
-        = task.period_month_name
+        = task.reporting_period
       - if current_user.multiple_suppliers?
         %h3.govuk-heading-m
           %span.govuk-visually-hidden

--- a/spec/models/api/task_spec.rb
+++ b/spec/models/api/task_spec.rb
@@ -44,9 +44,9 @@ RSpec.describe API::Task do
     end
   end
 
-  describe '#period_month_name' do
-    it 'returns the name of the month' do
-      expect(API::Task.new(period_month: 7).period_month_name).to eq('July')
+  describe '#reporting_period' do
+    it 'returns the month and year for the task' do
+      expect(API::Task.new(period_month: 7, period_year: 2018).reporting_period).to eq('July 2018')
     end
   end
 end


### PR DESCRIPTION
Now we've crossed into the new year we have tasks for both 2018 and 2019. We should show the years to uses to make it easier to determine the exact period for which they are reporting.

https://trello.com/c/z7YW1uIc/668-task-list-add-year-information