### PR TITLE
(600) Remove management charge (levy) from stubs

### DIFF
--- a/spec/fixtures/mocks/submission_completed_no_business.json
+++ b/spec/fixtures/mocks/submission_completed_no_business.json
@@ -9,7 +9,6 @@
       "order_count": 0,
       "purchase_order_number": null,
       "status": "completed",
-      "levy": 0,
       "report_no_business?": true
     }
   }

--- a/spec/fixtures/mocks/submission_completed_report_mi.json
+++ b/spec/fixtures/mocks/submission_completed_report_mi.json
@@ -9,7 +9,6 @@
       "order_count": 1,
       "purchase_order_number": null,
       "status": "completed",
-      "levy": 4500,
       "report_no_business?": false
     }
   }

--- a/spec/fixtures/mocks/submission_completed_with_task.json
+++ b/spec/fixtures/mocks/submission_completed_with_task.json
@@ -8,8 +8,7 @@
       "invoice_count": 2,
       "order_count": 1,
       "purchase_order_number": "PO123",
-      "status": "completed",
-      "levy": 4500
+      "status": "completed"
     },
     "relationships": {
       "task": {

--- a/spec/fixtures/mocks/submission_errored.json
+++ b/spec/fixtures/mocks/submission_errored.json
@@ -15,8 +15,7 @@
       "invoice_count": 2,
       "order_count": 1,
       "purchase_order_number": null,
-      "status": "validation_failed",
-      "levy": null
+      "status": "validation_failed"
     }
   }
 }

--- a/spec/fixtures/mocks/submission_validated.json
+++ b/spec/fixtures/mocks/submission_validated.json
@@ -8,8 +8,7 @@
       "invoice_count": 2,
       "order_count": 1,
       "purchase_order_number": "123",
-      "status": "in_review",
-      "levy": 4500
+      "status": "in_review"
     }
   }
 }

--- a/spec/fixtures/mocks/task_with_invalid_submission.json
+++ b/spec/fixtures/mocks/task_with_invalid_submission.json
@@ -29,7 +29,6 @@
         "framework_id": "f87717d4-874a-43d9-b99f-c8cf2897b526",
         "supplier_id": "cd40ead8-67b5-4918-abf0-ab8937cd04ff",
         "task_id": "2d98639e-5260-411f-a5ee-61847a2e067c",
-        "levy": null,
         "status": "validation_failed"
       }
     }

--- a/spec/fixtures/mocks/task_with_valid_submission.json
+++ b/spec/fixtures/mocks/task_with_valid_submission.json
@@ -29,7 +29,6 @@
         "framework_id": "f87717d4-874a-43d9-b99f-c8cf2897b526",
         "supplier_id": "cd40ead8-67b5-4918-abf0-ab8937cd04ff",
         "task_id": "2d98639e-5260-411f-a5ee-61847a2e067c",
-        "levy": 400.56,
         "status": "in_review"
       }
     }

--- a/spec/fixtures/mocks/tasks_with_framework_and_latest_submission.json
+++ b/spec/fixtures/mocks/tasks_with_framework_and_latest_submission.json
@@ -212,7 +212,6 @@
         "framework_id": "21e4a516-9852-49fd-9035-8006bdf76657",
         "supplier_id": "533a1357-4faf-4ced-b759-3e6da0bc5f3e",
         "task_id": "fc9deeb0-9804-42f7-ad8b-8b9878cce252",
-        "levy": null,
         "status": "pending"
       },
       "relationships": {
@@ -253,7 +252,6 @@
         "framework_id": "ec2aed23-7c4f-4de8-b4ad-afc54ecf882d",
         "supplier_id": "533a1357-4faf-4ced-b759-3e6da0bc5f3e",
         "task_id": "d211060f-e4fa-413a-928e-5928d0083db6",
-        "levy": null,
         "status": "processing"
       },
       "relationships": {
@@ -294,7 +292,6 @@
         "framework_id": "fbe9c2dd-ad80-4398-8c92-f50a6a47d92e",
         "supplier_id": "533a1357-4faf-4ced-b759-3e6da0bc5f3e",
         "task_id": "855d1dd2-d9b3-4432-8c17-b63e90e50bcd",
-        "levy": 40.50,
         "status": "in_review"
       },
       "relationships": {
@@ -335,7 +332,6 @@
         "framework_id": "7a50a178-3fb8-4c0a-9f2c-8841812448d1",
         "supplier_id": "533a1357-4faf-4ced-b759-3e6da0bc5f3e",
         "task_id": "b847e0f7-027e-4b95-afa2-3490b8d05a1c",
-        "levy": null,
         "status": "validation_failed"
       },
       "relationships": {
@@ -376,7 +372,6 @@
         "framework_id": "485c9fdd-cfc9-4b3c-9a69-a8195f9c13bc",
         "supplier_id": "533a1357-4faf-4ced-b759-3e6da0bc5f3e",
         "task_id": "141ccb6c-b5cb-4b05-9931-bd71d9ec3d96",
-        "levy": null,
         "status": "completed"
       },
       "relationships": {

--- a/spec/support/api_helpers.rb
+++ b/spec/support/api_helpers.rb
@@ -85,8 +85,7 @@ module ApiHelpers
           task_id: mock_task_id,
           framework_id: 'f87717d4-874a-43d9-b99f-c8cf2897b526',
           supplier_id: 'cd40ead8-67b5-4918-abf0-ab8937cd04ff',
-          status: 'completed',
-          levy: nil,
+          status: 'completed'
         }
       }
     }


### PR DESCRIPTION
I picked this card up from the inbox on a quiet day, I think this is what is needed, but please let me know if not.

After changing the term 'levy' to 'management charge' we realised the API does not return this property at all and so should not be included in the stubs, this removes them.
Resolves:
https://trello.com/c/l2PJ7Mwp