### PR TITLE
Update release process

### DIFF
--- a/RELEASE-PROCESS.md
+++ b/RELEASE-PROCESS.md
@@ -42,6 +42,8 @@ production deploy can be performed by manually merging `develop` into `master`:
   git checkout master
   git pull
   git merge origin/develop
+  # Edit the commit message to reference the release number
+  # e.g. "Release 43" or "merge origin/develop for release 43"
   git push
 ```
 


### PR DESCRIPTION
We noticed during deploy that to keep merge commits in line with the
convention used in the history that we needed to edit the merge commit
message to acknowledge the release. Put that in the process notes.