### PR TITLE
Suppress bootsnap require when using a debugger

### DIFF
--- a/config/boot.rb
+++ b/config/boot.rb
@@ -1,4 +1,10 @@
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
 
 require 'bundler/setup' # Set up gems listed in the Gemfile.
-require 'bootsnap/setup' # Speed up boot time by caching expensive operations.
+# Speed up boot time by caching expensive operations,
+# but allow disabling for debuggers like RubyMine 2018.1
+# that won't hit breakpoints when bootsnap is used.
+# This +unless+ can be removed from 2019.1 onwards.
+unless /ruby-debug-ide/.match?(ENV['RUBYLIB'])
+  require 'bootsnap/setup' # Speed up boot time by caching expensive operations.
+end


### PR DESCRIPTION
Bootsnap interferes with debuggers to the extent that breakpoints can't
be hit, so optionally, don't set up bootsnap when a debugger using
`ruby-debug-ide` is detected.

@mec this supersedes the solution you might have seen in your email in that it doesn't require any config change; we just detect the debugger and elect to not set up bootsnap when it's there.

This should let you get away from having to constantly check that the `require` you've commented out isn't being committed by accident 😄 

Source: https://youtrack.jetbrains.com/issue/RUBY-20684#focus=streamItem-27-3183071-0-0