### PR TITLE
(feature) Provide a friendly message when authentication fails

### DIFF
--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -8,4 +8,6 @@ class ErrorsController < ApplicationController
   def internal_server_error
     render status: :internal_server_error
   end
+
+  def auth_failure; end
 end

--- a/app/views/errors/auth_failure.html.haml
+++ b/app/views/errors/auth_failure.html.haml
@@ -1,0 +1,20 @@
+.govuk-grid-row
+  .govuk-grid-column-full
+    %h1.govuk-heading-xl
+      Report management information to CCS
+
+.govuk-grid-row
+  .govuk-grid-column-two-thirds
+    %p
+      We were unable to sign you in with the provided credentials. Please try again.
+
+    %p
+      %br
+      = link_to 'Sign in', '/auth/auth0', class: 'govuk-button govuk-button--start', id: 'sign-in', 'aria-label' => "Sign in to the service"
+
+    %p
+      If you are unable to sign in or do not receive a password reset email from the service contact
+      = support_email_address
+      %br
+      = succeed '.' do
+        = mail_to(support_email_address, 'Email sign in support')

--- a/app/views/home/guest_homepage.html.haml
+++ b/app/views/home/guest_homepage.html.haml
@@ -36,7 +36,8 @@
       If you don’t know or have forgotten your password you can reset it by starting the service and choosing ‘Don't remember your password?’ from the sign in screen.
 
     %p
-      If you are unable to sign in or do not receive a password reset email from the service contact report-mi@crowncommercial.gov.uk. 
+      If you are unable to sign in or do not receive a password reset email from the service contact
+      = support_email_address
       %br
       = succeed '.' do
         = mail_to(support_email_address, 'Email sign in support')
@@ -44,22 +45,22 @@
     %h3.govuk-heading-s
       Check which service to report to
     %p
-      Check the lists of frameworks that should be submitted through this service: 
+      Check the lists of frameworks that should be submitted through this service:
       %br
       = succeed '.' do
         = link_to('List of frameworks submitted through this service', '/support/frameworks')
 
     %p
-      For frameworks not listed, use the existing MISO service: 
+      For frameworks not listed, use the existing MISO service:
       %br
       = succeed '.' do
         = link_to('MISO service for frameworks not listed', 'https://miso.ccs.cabinetoffice.gov.uk/')
 
 
     %p
-      If you are unsure about which service to use email 
+      If you are unsure about which service to use email
       %br
-      report-mi@crowncommercial.gov.uk.
+      = support_email_address
       %br
       = succeed '.' do
         = mail_to(support_email_address, 'Email service support')

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,7 @@ Rails.application.routes.draw do
   end
 
   get '/auth/:provider/callback', to: 'sessions#create'
+  get '/auth/failure', to: 'errors#auth_failure'
   get '/sign_out', to: 'sessions#destroy', as: :sign_out
   get '/style_guide', to: 'styleguide#index'
   get '/urns', to: 'urns#index'

--- a/spec/features/users_can_sign_in_and_out_spec.rb
+++ b/spec/features/users_can_sign_in_and_out_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Signing in as a user' do
+RSpec.feature 'Signing in and out as a user' do
   scenario 'Signing in successfully' do
     mock_sso_with(email: 'email@example.com')
     mock_tasks_endpoint!
@@ -13,7 +13,17 @@ RSpec.feature 'Signing in as a user' do
     expect(page).to have_content 'Sign out'
   end
 
-  scenario 'Signing out' do
+  scenario 'Signing in unsuccessfully' do
+    mock_sso_failure(:invalid_credentials)
+
+    visit '/tasks'
+
+    click_on 'sign-in'
+
+    expect(page).to have_content 'We were unable to sign you in with the provided credentials'
+  end
+
+  scenario 'Signing out successfully' do
     mock_sso_with(email: 'email@example.com')
     mock_tasks_endpoint!
     mock_user_endpoint!

--- a/spec/support/single_sign_on_helpers.rb
+++ b/spec/support/single_sign_on_helpers.rb
@@ -9,4 +9,8 @@ module SingleSignOnHelpers
       }
     )
   end
+
+  def mock_sso_failure(message)
+    OmniAuth.config.mock_auth[:auth0] = message
+  end
 end


### PR DESCRIPTION
When Auth0 authentication fails (for whatever reason) the user was being redirected to `/auth/failure`, which resulted in a 404 and a Rollbar error.

This PR adds an authentication failed page, which invites the user to try logging in again.

<img width="1033" alt="screenshot 2019-02-14 at 14 49 23" src="https://user-images.githubusercontent.com/1089521/52801175-3af5b980-3075-11e9-8cd5-f18f08e7d65e.png">
