### PR TITLE
Remove hardcoded API host

### DIFF
--- a/spec/models/api/base_spec.rb
+++ b/spec/models/api/base_spec.rb
@@ -13,12 +13,12 @@ RSpec.describe API::Base do
   it 'includes the X-Auth-Id header in every request' do
     allow(Current).to receive(:auth_id).and_return('fake-auth-id')
 
-    stub_request(:get, 'https://ccs.api/v1/dummies/1234')
+    stub_request(:get, api_url('dummies/1234'))
 
     dummy_api_model.find('1234')
 
     expect(
-      a_request(:get, 'https://ccs.api/v1/dummies/1234')
+      a_request(:get, api_url('dummies/1234'))
       .with(headers: { 'X-Auth-Id': 'fake-auth-id' })
     ).to have_been_made
   end


### PR DESCRIPTION
This was failing tests on my local machine, and I imagine might for others too.