### PR TITLE
(815) Introduce show page for completed tasks

### DIFF
--- a/app/assets/stylesheets/components/_all.scss
+++ b/app/assets/stylesheets/components/_all.scss
@@ -6,6 +6,7 @@
 @import "govuk-frontend/components/table/table";
 @import "govuk-frontend/components/error-summary/error-summary";
 @import "govuk-frontend/components/back-link/back-link";
+@import "govuk-frontend/components/summary-list/summary-list";
 
 // custom
 @import "type/type";

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -7,6 +7,11 @@ class TasksController < ApplicationController
              .sort_by! { |t| Date.parse(t.due_on) }
   end
 
+  def show
+    @task = API::Task.includes(:framework, :latest_submission).find(params[:id]).first
+    @submission = @task.latest_submission
+  end
+
   def complete; end
 
   def history

--- a/app/views/tasks/history.html.haml
+++ b/app/views/tasks/history.html.haml
@@ -15,9 +15,11 @@
             %th.govuk-table__header Framework
             %th.govuk-table__header Month
             %th.govuk-table__header Completed
+            %th.govuk-table__header Actions
         %tbody.govuk-table__body
           - @tasks.each do |task|
             %tr.govuk-table__row
               %td.govuk-table__cell= task.framework.name
               %td.govuk-table__cell= task.reporting_period
               %td.govuk-table__cell= task.completed_at
+              %td.govuk-table__cell= link_to 'View', task_path(task)

--- a/app/views/tasks/show.html.haml
+++ b/app/views/tasks/show.html.haml
@@ -1,0 +1,55 @@
+.govuk-grid-row
+  .govuk-grid-column-full
+    = link_to 'Back', history_tasks_path, { class: 'govuk-back-link', title: 'Back to your task history' }
+
+.govuk-grid-row
+  .govuk-grid-column-full
+    %h1.govuk-heading-xl
+      Task
+
+    %dl.govuk-summary-list.govuk-summary-list--no-border
+      .govuk-summary-list__row
+        %dt.govuk-summary-list__key
+          Framework
+        %dd.govuk-summary-list__value
+          = @task.framework.short_name
+          = @task.framework.name
+      .govuk-summary-list__row
+        %dt.govuk-summary-list__key
+          Month
+        %dd.govuk-summary-list__value
+          = @task.reporting_period
+      .govuk-summary-list__row
+        %dt.govuk-summary-list__key
+          Completed
+        %dd.govuk-summary-list__value
+          = @task.completed_at
+
+    %h2.govuk-heading-m
+      Submitted management information
+
+    %dl.govuk-summary-list.govuk-summary-list--no-border
+      .govuk-summary-list__row
+        %dt.govuk-summary-list__key
+          Purchase order number
+        %dd.govuk-summary-list__value
+          = @submission.purchase_order_number
+
+    %table.govuk-table
+      %thead.govuk-table__head
+        %tr.govuk-table__row
+          %th.govuk-table__header{ scope: 'col' } Filename
+          %th.govuk-table__header.govuk-table__header--numeric{ scope: 'col' } Invoices
+          %th.govuk-table__header.govuk-table__header--numeric{ scope: 'col' } Contracts
+      %tbody.govuk-table__body
+        %tr.govuk-table__row
+          %td.govuk-table__cell
+            Uploaded file
+          %td.govuk-table__cell.govuk-table__cell--numeric
+            = pluralize(@submission.invoice_count, 'row')
+          %td.govuk-table__cell.govuk-table__cell--numeric
+            = pluralize(@submission.order_count, 'row')
+
+.govuk-grid-row
+  .govuk-grid-column-full
+    = link_to 'Back', history_tasks_path, { class: 'govuk-back-link', title: 'Back to your task history' }

--- a/app/views/tasks/show.html.haml
+++ b/app/views/tasks/show.html.haml
@@ -28,27 +28,31 @@
     %h2.govuk-heading-m
       Submitted management information
 
-    %dl.govuk-summary-list.govuk-summary-list--no-border
-      .govuk-summary-list__row
-        %dt.govuk-summary-list__key
-          Purchase order number
-        %dd.govuk-summary-list__value
-          = @submission.purchase_order_number
+    - if @submission.report_no_business?
+      %p
+        You reported no business
+    - else
+      %dl.govuk-summary-list.govuk-summary-list--no-border
+        .govuk-summary-list__row
+          %dt.govuk-summary-list__key
+            Purchase order number
+          %dd.govuk-summary-list__value
+            = @submission.purchase_order_number
 
-    %table.govuk-table
-      %thead.govuk-table__head
-        %tr.govuk-table__row
-          %th.govuk-table__header{ scope: 'col' } Filename
-          %th.govuk-table__header.govuk-table__header--numeric{ scope: 'col' } Invoices
-          %th.govuk-table__header.govuk-table__header--numeric{ scope: 'col' } Contracts
-      %tbody.govuk-table__body
-        %tr.govuk-table__row
-          %td.govuk-table__cell
-            Uploaded file
-          %td.govuk-table__cell.govuk-table__cell--numeric
-            = pluralize(@submission.invoice_count, 'row')
-          %td.govuk-table__cell.govuk-table__cell--numeric
-            = pluralize(@submission.order_count, 'row')
+      %table.govuk-table
+        %thead.govuk-table__head
+          %tr.govuk-table__row
+            %th.govuk-table__header{ scope: 'col' } Filename
+            %th.govuk-table__header.govuk-table__header--numeric{ scope: 'col' } Invoices
+            %th.govuk-table__header.govuk-table__header--numeric{ scope: 'col' } Contracts
+        %tbody.govuk-table__body
+          %tr.govuk-table__row
+            %td.govuk-table__cell
+              Uploaded file
+            %td.govuk-table__cell.govuk-table__cell--numeric
+              = pluralize(@submission.invoice_count, 'row')
+            %td.govuk-table__cell.govuk-table__cell--numeric
+              = pluralize(@submission.order_count, 'row')
 
 .govuk-grid-row
   .govuk-grid-column-full

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,7 @@ Rails.application.routes.draw do
   match '/404', to: 'errors#not_found', via: :all
   match '/500', to: 'errors#internal_server_error', via: :all
 
-  resources :tasks, only: %i[index] do
+  resources :tasks, only: %i[index show] do
     collection do
       get :history
     end

--- a/spec/fixtures/mocks/completed_task.json
+++ b/spec/fixtures/mocks/completed_task.json
@@ -1,0 +1,55 @@
+{
+  "data": {
+    "id": "2d98639e-5260-411f-a5ee-61847a2e067c",
+    "type": "tasks",
+    "attributes": {
+      "description": null,
+      "due_on": "2030-01-01",
+      "period_month": 7,
+      "period_year": 2018,
+      "status": "completed",
+      "framework_id": "f87717d4-874a-43d9-b99f-c8cf2897b526",
+      "supplier_id": "cd40ead8-67b5-4918-abf0-ab8937cd04ff",
+      "supplier_name": "Bobs Cheese Shop"
+    },
+    "relationships": {
+      "framework": {
+        "data": {
+          "type": "frameworks",
+          "id": "f87717d4-874a-43d9-b99f-c8cf2897b526"
+        }
+      },
+      "latest_submission": {
+        "data": {
+          "type": "submissions",
+          "id": "663f8bf9-464b-4d2f-8532-7404ae76063c"
+        }
+      }
+    }
+  },
+  "included": [
+    {
+      "id": "f87717d4-874a-43d9-b99f-c8cf2897b526",
+      "type": "frameworks",
+      "attributes": {
+        "short_name": "CBOARD5",
+        "name": "Cheese Board 5"
+      }
+    },
+    {
+      "id": "663f8bf9-464b-4d2f-8532-7404ae76063c",
+      "type": "submissions",
+      "attributes": {
+        "framework_id": "485c9fdd-cfc9-4b3c-9a69-a8195f9c13bc",
+        "supplier_id": "533a1357-4faf-4ced-b759-3e6da0bc5f3e",
+        "task_id": "141ccb6c-b5cb-4b05-9931-bd71d9ec3d96",
+        "report_no_business?": false,
+        "status": "completed",
+        "submitted_at": "2019-02-14T15:39:38.151Z",
+        "purchase_order_number": "PO123",
+        "invoice_count": 42,
+        "order_count": 99
+      }
+    }
+  ]
+}

--- a/spec/fixtures/mocks/completed_task_with_no_business.json
+++ b/spec/fixtures/mocks/completed_task_with_no_business.json
@@ -1,0 +1,55 @@
+{
+  "data": {
+    "id": "2d98639e-5260-411f-a5ee-61847a2e067c",
+    "type": "tasks",
+    "attributes": {
+      "description": null,
+      "due_on": "2030-01-01",
+      "period_month": 7,
+      "period_year": 2018,
+      "status": "completed",
+      "framework_id": "f87717d4-874a-43d9-b99f-c8cf2897b526",
+      "supplier_id": "cd40ead8-67b5-4918-abf0-ab8937cd04ff",
+      "supplier_name": "Bobs Cheese Shop"
+    },
+    "relationships": {
+      "framework": {
+        "data": {
+          "type": "frameworks",
+          "id": "f87717d4-874a-43d9-b99f-c8cf2897b526"
+        }
+      },
+      "latest_submission": {
+        "data": {
+          "type": "submissions",
+          "id": "663f8bf9-464b-4d2f-8532-7404ae76063c"
+        }
+      }
+    }
+  },
+  "included": [
+    {
+      "id": "f87717d4-874a-43d9-b99f-c8cf2897b526",
+      "type": "frameworks",
+      "attributes": {
+        "short_name": "CBOARD5",
+        "name": "Cheese Board 5"
+      }
+    },
+    {
+      "id": "663f8bf9-464b-4d2f-8532-7404ae76063c",
+      "type": "submissions",
+      "attributes": {
+        "framework_id": "485c9fdd-cfc9-4b3c-9a69-a8195f9c13bc",
+        "supplier_id": "533a1357-4faf-4ced-b759-3e6da0bc5f3e",
+        "task_id": "141ccb6c-b5cb-4b05-9931-bd71d9ec3d96",
+        "report_no_business?": true,
+        "status": "completed",
+        "submitted_at": "2019-02-14T15:39:38.151Z",
+        "purchase_order_number": null,
+        "invoice_count": 0,
+        "order_count": 0
+      }
+    }
+  ]
+}

--- a/spec/requests/tasks_spec.rb
+++ b/spec/requests/tasks_spec.rb
@@ -109,4 +109,18 @@ RSpec.describe 'the tasks list' do
       expect(response.body).to include '14 February 2019 15:39 UTC'
     end
   end
+
+  context 'when viewing a completed task that reported business' do
+    before do
+      stub_signed_in_user
+      mock_completed_task_endpoint!
+
+      get task_path(mock_task_id)
+    end
+
+    it 'shows details of the task and submission' do
+      expect(response.body).to include 'Submitted management information'
+      expect(response.body).to include '42 rows'
+    end
+  end
 end

--- a/spec/requests/tasks_spec.rb
+++ b/spec/requests/tasks_spec.rb
@@ -123,4 +123,18 @@ RSpec.describe 'the tasks list' do
       expect(response.body).to include '42 rows'
     end
   end
+
+  context 'when viewing a completed task that reported no business' do
+    before do
+      stub_signed_in_user
+      mock_completed_task_with_no_business_endpoint!
+
+      get task_path(mock_task_id)
+    end
+
+    it 'shows details of the task and no business submission' do
+      expect(response.body).to include 'Submitted management information'
+      expect(response.body).to include 'You reported no business'
+    end
+  end
 end

--- a/spec/support/api_helpers.rb
+++ b/spec/support/api_helpers.rb
@@ -140,6 +140,11 @@ module ApiHelpers
       .to_return(headers: json_headers, body: '{}')
   end
 
+  def mock_completed_task_endpoint!
+    stub_request(:get, api_url("tasks/#{mock_task_id}?include=framework,latest_submission"))
+      .to_return(headers: json_headers, body: json_fixture_file('completed_task.json'))
+  end
+
   def mock_create_submission_endpoint!
     task_submission = {
       data: {

--- a/spec/support/api_helpers.rb
+++ b/spec/support/api_helpers.rb
@@ -145,6 +145,11 @@ module ApiHelpers
       .to_return(headers: json_headers, body: json_fixture_file('completed_task.json'))
   end
 
+  def mock_completed_task_with_no_business_endpoint!
+    stub_request(:get, api_url("tasks/#{mock_task_id}?include=framework,latest_submission"))
+      .to_return(headers: json_headers, body: json_fixture_file('completed_task_with_no_business.json'))
+  end
+
   def mock_create_submission_endpoint!
     task_submission = {
       data: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3,5 +3,5 @@
 
 
 govuk-frontend@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/govuk-frontend/-/govuk-frontend-2.0.0.tgz#daf69eeffc60d013ad5fd14b59e5e488ac63a132"
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/govuk-frontend/-/govuk-frontend-2.7.0.tgz#6a12baf514426653220dd3cdef55b1e1d97f52a6"


### PR DESCRIPTION
This is the page where suppliers will be able to perform a replacement. We're putting together the bare-minimum page now to unblock the work on replacement returns. Separate work is being carried out to a) expose the extra data we want to display on this page via the API (e.g. uploaded filename, spend totals) and b) update this page to display the new information.

Summary for a business return:
![screenshot 2019-02-25 at 15 55 43](https://user-images.githubusercontent.com/3687/53349800-cf81d680-3915-11e9-9a60-9ec6593ac15f.png)

Summary for a no-business return:

![screenshot 2019-02-25 at 15 56 44](https://user-images.githubusercontent.com/3687/53349879-f50ee000-3915-11e9-9c0d-61f816f9281f.png)

