### PR TITLE
(815) Update Tasks#index / Tasks#history to only request fields they need

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -1,6 +1,7 @@
 class TasksController < ApplicationController
   def index
     @tasks = API::Task
+             .select(submissions: %i[status submitted_at])
              .where(status: ['unstarted', 'in_progress'])
              .includes(:framework, :latest_submission)
              .all
@@ -16,6 +17,7 @@ class TasksController < ApplicationController
 
   def history
     @tasks = API::Task
+             .select(submissions: %i[status submitted_at])
              .where(status: 'completed')
              .includes(:framework, :latest_submission)
              .all

--- a/spec/fixtures/mocks/complete_tasks_with_framework_and_latest_submission.json
+++ b/spec/fixtures/mocks/complete_tasks_with_framework_and_latest_submission.json
@@ -39,9 +39,6 @@
       "id": "663f8bf9-464b-4d2f-8532-7404ae76063c",
       "type": "submissions",
       "attributes": {
-        "framework_id": "485c9fdd-cfc9-4b3c-9a69-a8195f9c13bc",
-        "supplier_id": "533a1357-4faf-4ced-b759-3e6da0bc5f3e",
-        "task_id": "141ccb6c-b5cb-4b05-9931-bd71d9ec3d96",
         "status": "completed",
         "submitted_at": "2019-02-14T15:39:38.151Z"
       },

--- a/spec/fixtures/mocks/incomplete_tasks_with_framework_and_latest_submission.json
+++ b/spec/fixtures/mocks/incomplete_tasks_with_framework_and_latest_submission.json
@@ -176,10 +176,8 @@
       "id": "63996088-5c20-4e65-b722-287fafeedc97",
       "type": "submissions",
       "attributes": {
-        "framework_id": "21e4a516-9852-49fd-9035-8006bdf76657",
-        "supplier_id": "533a1357-4faf-4ced-b759-3e6da0bc5f3e",
-        "task_id": "fc9deeb0-9804-42f7-ad8b-8b9878cce252",
-        "status": "pending"
+        "status": "pending",
+        "submitted_at": null
       },
       "relationships": {
         "framework": {
@@ -216,10 +214,8 @@
       "id": "65b11138-8c7e-4427-93a2-c5da3a7c3f9d",
       "type": "submissions",
       "attributes": {
-        "framework_id": "ec2aed23-7c4f-4de8-b4ad-afc54ecf882d",
-        "supplier_id": "533a1357-4faf-4ced-b759-3e6da0bc5f3e",
-        "task_id": "d211060f-e4fa-413a-928e-5928d0083db6",
-        "status": "processing"
+        "status": "processing",
+        "submitted_at": null
       },
       "relationships": {
         "framework": {
@@ -256,10 +252,8 @@
       "id": "67e7a34f-5d4c-4946-b045-da77f4b651db",
       "type": "submissions",
       "attributes": {
-        "framework_id": "fbe9c2dd-ad80-4398-8c92-f50a6a47d92e",
-        "supplier_id": "533a1357-4faf-4ced-b759-3e6da0bc5f3e",
-        "task_id": "855d1dd2-d9b3-4432-8c17-b63e90e50bcd",
-        "status": "in_review"
+        "status": "in_review",
+        "submitted_at": null
       },
       "relationships": {
         "framework": {
@@ -296,10 +290,8 @@
       "id": "43dfbd10-1c17-4f3c-8665-be8c2776249b",
       "type": "submissions",
       "attributes": {
-        "framework_id": "7a50a178-3fb8-4c0a-9f2c-8841812448d1",
-        "supplier_id": "533a1357-4faf-4ced-b759-3e6da0bc5f3e",
-        "task_id": "b847e0f7-027e-4b95-afa2-3490b8d05a1c",
-        "status": "validation_failed"
+        "status": "validation_failed",
+        "submitted_at": null
       },
       "relationships": {
         "framework": {


### PR DESCRIPTION
Now the tasks endpoint on the API supports sparse fieldsets (https://github.com/dxw/DataSubmissionServiceAPI/pull/276), we can restrict which fields are requested, which cuts down the amount of processing the API has to do.

We've updated the request mocks that hit this endpoint, so that any future frontend changes which try to read other fields will result in test failures.