### PR TITLE
(815) Add invoice/order total values and uploaded filename to Task#show page

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -9,8 +9,9 @@ class TasksController < ApplicationController
   end
 
   def show
-    @task = API::Task.includes(:framework, :latest_submission).find(params[:id]).first
+    @task = API::Task.includes(:framework, latest_submission: :files).find(params[:id]).first
     @submission = @task.latest_submission
+    @file = @submission.files&.first
   end
 
   def complete; end

--- a/app/views/tasks/show.html.haml
+++ b/app/views/tasks/show.html.haml
@@ -33,11 +33,12 @@
         You reported no business
     - else
       %dl.govuk-summary-list.govuk-summary-list--no-border
-        .govuk-summary-list__row
-          %dt.govuk-summary-list__key
-            Purchase order number
-          %dd.govuk-summary-list__value
-            = @submission.purchase_order_number
+        - if @submission.purchase_order_number.present?
+          .govuk-summary-list__row
+            %dt.govuk-summary-list__key
+              Purchase order number
+            %dd.govuk-summary-list__value
+              = @submission.purchase_order_number
 
       %table.govuk-table
         %thead.govuk-table__head
@@ -48,11 +49,18 @@
         %tbody.govuk-table__body
           %tr.govuk-table__row
             %td.govuk-table__cell
-              Uploaded file
+              = @file.filename
             %td.govuk-table__cell.govuk-table__cell--numeric
               = pluralize(@submission.invoice_count, 'row')
             %td.govuk-table__cell.govuk-table__cell--numeric
               = pluralize(@submission.order_count, 'row')
+          %tr.govuk-table__row
+            %td.govuk-table__cell
+            %td.govuk-table__cell.govuk-table__cell--numeric
+              = number_to_currency(@submission.invoice_total_value, unit: '£')
+            %td.govuk-table__cell.govuk-table__cell--numeric
+              = number_to_currency(@submission.order_total_value, unit: '£')
+
 
 .govuk-grid-row
   .govuk-grid-column-full

--- a/spec/fixtures/mocks/completed_task.json
+++ b/spec/fixtures/mocks/completed_task.json
@@ -48,7 +48,26 @@
         "submitted_at": "2019-02-14T15:39:38.151Z",
         "purchase_order_number": "PO123",
         "invoice_count": 42,
-        "order_count": 99
+        "order_count": 99,
+        "invoice_total_value": 12345.67,
+        "order_total_value": 987.65
+      },
+      "relationships": {
+        "files": {
+          "data": {
+            "type": "submission_files",
+            "id": "8f62dc3a-4765-48d0-9544-e850ff8c3b80"
+          }
+        }
+      }
+    },
+    {
+      "id": "8f62dc3a-4765-48d0-9544-e850ff8c3b80",
+      "type": "submission_files",
+      "attributes": {
+        "submission_id": "663f8bf9-464b-4d2f-8532-7404ae76063c",
+        "rows": 6,
+        "filename": "RM3786 MISO Data Template (August 2018).xls"
       }
     }
   ]

--- a/spec/fixtures/mocks/completed_task_with_no_business.json
+++ b/spec/fixtures/mocks/completed_task_with_no_business.json
@@ -49,6 +49,11 @@
         "purchase_order_number": null,
         "invoice_count": 0,
         "order_count": 0
+      },
+      "relationships": {
+        "files": {
+          "data": []
+        }
       }
     }
   ]

--- a/spec/requests/tasks_spec.rb
+++ b/spec/requests/tasks_spec.rb
@@ -121,6 +121,8 @@ RSpec.describe 'the tasks list' do
     it 'shows details of the task and submission' do
       expect(response.body).to include 'Submitted management information'
       expect(response.body).to include '42 rows'
+      expect(response.body).to include '£12,345.67'
+      expect(response.body).to include 'RM3786 MISO Data Template (August 2018).xls'
     end
   end
 

--- a/spec/support/api_helpers.rb
+++ b/spec/support/api_helpers.rb
@@ -141,12 +141,12 @@ module ApiHelpers
   end
 
   def mock_completed_task_endpoint!
-    stub_request(:get, api_url("tasks/#{mock_task_id}?include=framework,latest_submission"))
+    stub_request(:get, api_url("tasks/#{mock_task_id}?include=framework,latest_submission.files"))
       .to_return(headers: json_headers, body: json_fixture_file('completed_task.json'))
   end
 
   def mock_completed_task_with_no_business_endpoint!
-    stub_request(:get, api_url("tasks/#{mock_task_id}?include=framework,latest_submission"))
+    stub_request(:get, api_url("tasks/#{mock_task_id}?include=framework,latest_submission.files"))
       .to_return(headers: json_headers, body: json_fixture_file('completed_task_with_no_business.json'))
   end
 


### PR DESCRIPTION
These are now being exposed by the task API endpoint (https://github.com/dxw/DataSubmissionServiceAPI/pull/281), so we can now display them to the user:

<img width="1052" alt="screenshot 2019-02-27 at 15 39 06" src="https://user-images.githubusercontent.com/3166/53502397-dfc8bb80-3aa5-11e9-95f7-d0b5e8c8f55b.png">

Because the filename is exposed on the `SubmissionFile` model, this association is included in the API request, so the mocks have been updated accordingly.

