### PR TITLE
(834) User can download their submission files

### DIFF
--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -20,6 +20,16 @@ class SubmissionsController < ApplicationController
     render template_for_submission(@submission)
   end
 
+  def download
+    submission = API::Submission
+                 .includes(:files)
+                 .find(params[:id]).first
+
+    file = submission.files.first
+
+    redirect_to file.temporary_download_url, status: :temporary_redirect
+  end
+
   private
 
   def upload_file_submission(task, upload)

--- a/app/views/tasks/show.html.haml
+++ b/app/views/tasks/show.html.haml
@@ -58,7 +58,7 @@
         %tbody.govuk-table__body
           %tr.govuk-table__row
             %td.govuk-table__cell
-              = @file.filename
+              = link_to(@file.filename, download_task_submission_path(@task, @submission))
             %td.govuk-table__cell.govuk-table__cell--numeric
               = pluralize(@submission.invoice_count, 'row')
             %td.govuk-table__cell.govuk-table__cell--numeric

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,10 @@ Rails.application.routes.draw do
       get :correct
     end
     resources :submissions, only: %i[new create show] do
+      member do
+        get :download
+      end
+
       resource :complete, only: :create, controller: 'submission_completion'
     end
     resource :template, only: %i[show]

--- a/spec/features/users_can_download_their_submissions_spec.rb
+++ b/spec/features/users_can_download_their_submissions_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.feature 'downloading a submission' do
+  scenario 'user sees a download link' do
+    mock_sso_with(email: 'email@example.com')
+    mock_user_endpoint!
+    mock_incomplete_tasks_endpoint!
+
+    mock_completed_task_endpoint!
+
+    visit '/'
+    click_link 'sign-in'
+
+    visit "/tasks/#{mock_task_id}"
+
+    expect(page).to have_link(
+      'RM3786 MISO Data Template (August 2018).xls',
+      href: download_task_submission_path(mock_task_id, mock_submission_id)
+    )
+  end
+end

--- a/spec/fixtures/mocks/completed_task.json
+++ b/spec/fixtures/mocks/completed_task.json
@@ -22,7 +22,7 @@
       "latest_submission": {
         "data": {
           "type": "submissions",
-          "id": "663f8bf9-464b-4d2f-8532-7404ae76063c"
+          "id": "9a5ef62c-0781-4f80-8850-5793652b6b40"
         }
       }
     }
@@ -37,7 +37,7 @@
       }
     },
     {
-      "id": "663f8bf9-464b-4d2f-8532-7404ae76063c",
+      "id": "9a5ef62c-0781-4f80-8850-5793652b6b40",
       "type": "submissions",
       "attributes": {
         "framework_id": "485c9fdd-cfc9-4b3c-9a69-a8195f9c13bc",
@@ -65,9 +65,10 @@
       "id": "8f62dc3a-4765-48d0-9544-e850ff8c3b80",
       "type": "submission_files",
       "attributes": {
-        "submission_id": "663f8bf9-464b-4d2f-8532-7404ae76063c",
+        "submission_id": "9a5ef62c-0781-4f80-8850-5793652b6b40",
         "rows": 6,
-        "filename": "RM3786 MISO Data Template (August 2018).xls"
+        "filename": "RM3786 MISO Data Template (August 2018).xls",
+        "temporary_download_url": "https://s3.example.com/example.xls"
       }
     }
   ]

--- a/spec/fixtures/mocks/completed_task_with_no_business.json
+++ b/spec/fixtures/mocks/completed_task_with_no_business.json
@@ -22,7 +22,7 @@
       "latest_submission": {
         "data": {
           "type": "submissions",
-          "id": "663f8bf9-464b-4d2f-8532-7404ae76063c"
+          "id": "9a5ef62c-0781-4f80-8850-5793652b6b40"
         }
       }
     }
@@ -37,7 +37,7 @@
       }
     },
     {
-      "id": "663f8bf9-464b-4d2f-8532-7404ae76063c",
+      "id": "9a5ef62c-0781-4f80-8850-5793652b6b40",
       "type": "submissions",
       "attributes": {
         "framework_id": "485c9fdd-cfc9-4b3c-9a69-a8195f9c13bc",

--- a/spec/fixtures/mocks/submission_with_file.json
+++ b/spec/fixtures/mocks/submission_with_file.json
@@ -1,0 +1,39 @@
+{
+  "data": {
+    "id": "9a5ef62c-0781-4f80-8850-5793652b6b40",
+    "type": "submissions",
+    "attributes": {
+      "framework_id": "f87717d4-874a-43d9-b99f-c8cf2897b526",
+      "supplier_id": "cd40ead8-67b5-4918-abf0-ab8937cd04ff",
+      "invoice_count": 2,
+      "order_count": 1,
+      "invoice_total_value": 123.45,
+      "order_total_value": 42.42,
+      "purchase_order_number": null,
+      "status": "completed",
+      "report_no_business?": false
+    },
+    "relationships": {
+      "files": {
+        "data": [
+          {
+            "type": "submission_files",
+            "id": "8d0e4289-5fde-4faa-b78e-922846d8460a"
+          }
+        ]
+      }
+    }
+  },
+  "included": [
+    {
+      "id": "8d0e4289-5fde-4faa-b78e-922846d8460a",
+      "type": "submission_files",
+      "attributes": {
+        "submission_id": "9a5ef62c-0781-4f80-8850-5793652b6b40",
+        "temporary_download_url": "http://s3.example.com/example.xls",
+        "filename": "example.xls",
+        "rows": 3
+      }
+    }
+  ]
+}

--- a/spec/requests/submissions_download_spec.rb
+++ b/spec/requests/submissions_download_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+RSpec.describe 'downloading a submission' do
+  it 'redirects the user to the S3 download link' do
+    stub_signed_in_user
+
+    mock_submission_with_file_endpoint!
+
+    get download_task_submission_path(mock_task_id, mock_submission_id)
+
+    expect(response.status).to eql 307
+    expect(response).to redirect_to('http://s3.example.com/example.xls')
+  end
+end

--- a/spec/support/api_helpers.rb
+++ b/spec/support/api_helpers.rb
@@ -76,6 +76,13 @@ module ApiHelpers
       .to_return(status: 204, body: '', headers: json_headers)
   end
 
+  def mock_submission_with_file_endpoint!
+    stub_request(
+      :get,
+      api_url("submissions/#{mock_submission_id}?include=files")
+    ).to_return(headers: json_headers, body: json_fixture_file('submission_with_file.json'))
+  end
+
   def mock_no_business_endpoint!
     no_business_submission = {
       data: {


### PR DESCRIPTION
On the `Task#show` page, make the submission file downloadable, by clicking on its filename. This sends the user to the `Submissions#download` action which then redirects the user to the temporary (S3) download URL, that gets returned from the API.

![screenshot 2019-03-04 at 15 48 49](https://user-images.githubusercontent.com/3166/53744474-0a938500-3e95-11e9-8d49-6f8ace146bdc.png)

NB: I updated the submission id used in `completed_task.json` to use the `mocked_submission_id` value used elsewhere, in order to get the download test to pass. For consistency, I also updated the id used in `completed_task_with_no_business.json`.