### PR TITLE
Use active_submission instead of latest_submission

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -3,22 +3,22 @@ class TasksController < ApplicationController
     @tasks = API::Task
              .select(submissions: %i[status submitted_at])
              .where(status: ['unstarted', 'in_progress'])
-             .includes(:framework, :latest_submission)
+             .includes(:framework, :active_submission)
              .all
              .sort_by! { |t| Date.parse(t.due_on) }
   end
 
   def show
-    @task = API::Task.includes(:framework, latest_submission: :files).find(params[:id]).first
-    @submission = @task.latest_submission
+    @task = API::Task.includes(:framework, active_submission: :files).find(params[:id]).first
+    @submission = @task.active_submission
     @file = @submission.files&.first
   end
 
   def complete; end
 
   def correct
-    @task = API::Task.includes(:framework, latest_submission: :files).find(params[:id]).first
-    @submission = @task.latest_submission
+    @task = API::Task.includes(:framework, active_submission: :files).find(params[:id]).first
+    @submission = @task.active_submission
     @file = @submission.files&.first
   end
 
@@ -26,7 +26,7 @@ class TasksController < ApplicationController
     @tasks = API::Task
              .select(submissions: %i[status submitted_at])
              .where(status: 'completed')
-             .includes(:framework, :latest_submission)
+             .includes(:framework, :active_submission)
              .all
              .sort_by! { |t| Date.parse(t.due_on) }
   end

--- a/app/models/api/task.rb
+++ b/app/models/api/task.rb
@@ -1,7 +1,7 @@
 module API
   class Task < Base
     has_one :framework
-    has_one :latest_submission, class_name: 'API::Submission'
+    has_one :active_submission, class_name: 'API::Submission'
 
     custom_endpoint :no_business, on: :member, request_method: :post
 
@@ -10,7 +10,7 @@ module API
     end
 
     def errors?
-      (latest_submission.try(:status) == 'validation_failed') || false
+      (active_submission.try(:status) == 'validation_failed') || false
     end
 
     def late?
@@ -22,9 +22,9 @@ module API
     end
 
     def completed_at
-      return unless latest_submission.submitted_at
+      return unless active_submission.submitted_at
 
-      Time.zone.parse(latest_submission.submitted_at).to_s(:date_with_utc_time)
+      Time.zone.parse(active_submission.submitted_at).to_s(:date_with_utc_time)
     end
   end
 end

--- a/app/views/tasks/_task.html.haml
+++ b/app/views/tasks/_task.html.haml
@@ -32,7 +32,7 @@
     .ccs-task__action--primary
       - case task.status
       - when 'in_progress'
-        = render 'submission_buttons', task: task, submission: task.latest_submission
+        = render 'submission_buttons', task: task, submission: task.active_submission
       - when 'unstarted'
         = link_to 'Report management information', new_task_submission_path(task_id: task.id),  {class: 'govuk-button', 'aria-label' => "Report management information for #{task.supplier_name} on #{task.framework.short_name}"}
         = link_to 'Report no business', new_task_no_business_path(task_id: task.id), {class: 'govuk-button', 'aria-label' => "Report no business for #{task.supplier_name} on #{task.framework.short_name}"}

--- a/spec/fixtures/mocks/complete_tasks_with_framework_and_active_submission.json
+++ b/spec/fixtures/mocks/complete_tasks_with_framework_and_active_submission.json
@@ -14,7 +14,7 @@
         "period_month": 7
       },
       "relationships": {
-        "latest_submission": {
+        "active_submission": {
           "data": {
             "type": "submissions",
             "id": "663f8bf9-464b-4d2f-8532-7404ae76063c"

--- a/spec/fixtures/mocks/completed_task.json
+++ b/spec/fixtures/mocks/completed_task.json
@@ -19,7 +19,7 @@
           "id": "f87717d4-874a-43d9-b99f-c8cf2897b526"
         }
       },
-      "latest_submission": {
+      "active_submission": {
         "data": {
           "type": "submissions",
           "id": "9a5ef62c-0781-4f80-8850-5793652b6b40"

--- a/spec/fixtures/mocks/completed_task_with_no_business.json
+++ b/spec/fixtures/mocks/completed_task_with_no_business.json
@@ -19,7 +19,7 @@
           "id": "f87717d4-874a-43d9-b99f-c8cf2897b526"
         }
       },
-      "latest_submission": {
+      "active_submission": {
         "data": {
           "type": "submissions",
           "id": "9a5ef62c-0781-4f80-8850-5793652b6b40"

--- a/spec/fixtures/mocks/incomplete_tasks_with_framework_and_active_submission.json
+++ b/spec/fixtures/mocks/incomplete_tasks_with_framework_and_active_submission.json
@@ -14,7 +14,7 @@
         "period_month": 7
       },
       "relationships": {
-        "latest_submission": {
+        "active_submission": {
           "data": null
         },
         "submissions": {
@@ -44,7 +44,7 @@
         "period_month": 7
       },
       "relationships": {
-        "latest_submission": {
+        "active_submission": {
           "data": {
             "type": "submissions",
             "id": "63996088-5c20-4e65-b722-287fafeedc97"
@@ -77,7 +77,7 @@
         "period_month": 7
       },
       "relationships": {
-        "latest_submission": {
+        "active_submission": {
           "data": {
             "type": "submissions",
             "id": "65b11138-8c7e-4427-93a2-c5da3a7c3f9d"
@@ -110,7 +110,7 @@
         "period_month": 8
       },
       "relationships": {
-        "latest_submission": {
+        "active_submission": {
           "data": {
             "type": "submissions",
             "id": "67e7a34f-5d4c-4946-b045-da77f4b651db"
@@ -143,7 +143,7 @@
         "period_month": 7
       },
       "relationships": {
-        "latest_submission": {
+        "active_submission": {
           "data": {
             "type": "submissions",
             "id": "43dfbd10-1c17-4f3c-8665-be8c2776249b"

--- a/spec/fixtures/mocks/task_with_invalid_submission.json
+++ b/spec/fixtures/mocks/task_with_invalid_submission.json
@@ -13,7 +13,7 @@
       "supplier_name": "Bobs Cheese Shop"
     },
     "relationships": {
-      "latest_submission": {
+      "active_submission": {
         "data": {
           "type": "submissions",
           "id": "63996088-5c20-4e65-b722-287fafeedc97"

--- a/spec/fixtures/mocks/task_with_valid_submission.json
+++ b/spec/fixtures/mocks/task_with_valid_submission.json
@@ -13,7 +13,7 @@
       "supplier_name": "Bobs Cheese Shop"
     },
     "relationships": {
-      "latest_submission": {
+      "active_submission": {
         "data": {
           "type": "submissions",
           "id": "63996088-5c20-4e65-b722-287fafeedc97"

--- a/spec/models/api/task_spec.rb
+++ b/spec/models/api/task_spec.rb
@@ -13,14 +13,14 @@ RSpec.describe API::Task do
   describe '#errors?' do
     it 'returns true if the latest submission is errored' do
       mock_task_with_invalid_submission_endpoint!
-      task_with_invalid_submission = API::Task.includes(:latest_submission).find(mock_task_id).first
+      task_with_invalid_submission = API::Task.includes(:active_submission).find(mock_task_id).first
 
       expect(task_with_invalid_submission.errors?).to be_truthy
     end
 
     it 'returns false if the latest submission is not errored' do
       mock_task_with_valid_submission_endpoint!
-      task_with_valid_submission = API::Task.includes(:latest_submission).find(mock_task_id).first
+      task_with_valid_submission = API::Task.includes(:active_submission).find(mock_task_id).first
 
       expect(task_with_valid_submission.errors?).to be_falsy
     end

--- a/spec/support/api_helpers.rb
+++ b/spec/support/api_helpers.rb
@@ -134,12 +134,12 @@ module ApiHelpers
   end
 
   def mock_task_with_invalid_submission_endpoint!
-    stub_request(:get, api_url("tasks/#{mock_task_id}?include=latest_submission"))
+    stub_request(:get, api_url("tasks/#{mock_task_id}?include=active_submission"))
       .to_return(headers: json_headers, body: json_fixture_file('task_with_invalid_submission.json'))
   end
 
   def mock_task_with_valid_submission_endpoint!
-    stub_request(:get, api_url("tasks/#{mock_task_id}?include=latest_submission"))
+    stub_request(:get, api_url("tasks/#{mock_task_id}?include=active_submission"))
       .to_return(headers: json_headers, body: json_fixture_file('task_with_valid_submission.json'))
   end
 
@@ -148,7 +148,7 @@ module ApiHelpers
       .with(query: hash_including(filter: hash_including('status' => ['unstarted', 'in_progress'])))
       .to_return(
         headers: json_headers,
-        body: json_fixture_file('incomplete_tasks_with_framework_and_latest_submission.json')
+        body: json_fixture_file('incomplete_tasks_with_framework_and_active_submission.json')
       )
   end
 
@@ -157,7 +157,7 @@ module ApiHelpers
       .with(query: hash_including(filter: hash_including('status' => 'completed')))
       .to_return(
         headers: json_headers,
-        body: json_fixture_file('complete_tasks_with_framework_and_latest_submission.json')
+        body: json_fixture_file('complete_tasks_with_framework_and_active_submission.json')
       )
   end
 
@@ -168,12 +168,12 @@ module ApiHelpers
   end
 
   def mock_completed_task_endpoint!
-    stub_request(:get, api_url("tasks/#{mock_task_id}?include=framework,latest_submission.files"))
+    stub_request(:get, api_url("tasks/#{mock_task_id}?include=framework,active_submission.files"))
       .to_return(headers: json_headers, body: json_fixture_file('completed_task.json'))
   end
 
   def mock_completed_task_with_no_business_endpoint!
-    stub_request(:get, api_url("tasks/#{mock_task_id}?include=framework,latest_submission.files"))
+    stub_request(:get, api_url("tasks/#{mock_task_id}?include=framework,active_submission.files"))
       .to_return(headers: json_headers, body: json_fixture_file('completed_task_with_no_business.json'))
   end
 


### PR DESCRIPTION
Now that we have defined an `active_submission` in the API[1], we can use it everywhere we used to call `latest_submission`.

This step will enable us to remove the deprecated `latest_submission` from the API.

[1] https://github.com/dxw/DataSubmissionServiceAPI/pull/298

Co-authored-by: james <james@abscond.org>

Note: only merge after https://github.com/dxw/DataSubmissionServiceAPI/pull/298 is merged and deployed.