### PR TITLE
Set the class of the show task report no business

### DIFF
--- a/app/views/tasks/show.html.haml
+++ b/app/views/tasks/show.html.haml
@@ -7,6 +7,8 @@
     %h1.govuk-heading-xl
       Task
 
+.govuk-grid-row
+  .govuk-grid-column-two-thirds
     %dl.govuk-summary-list.govuk-summary-list--no-border
       .govuk-summary-list__row
         %dt.govuk-summary-list__key
@@ -34,11 +36,13 @@
           %dd.govuk-summary-list__value
             = @task.supplier_name
 
+.govuk-grid-row
+  .govuk-grid-column-full
     %h2.govuk-heading-m
       Submitted management information
 
     - if @submission.report_no_business?
-      %p
+      %p.ccs-return.ccs-return--no-business
         You reported no business
     - else
       %dl.govuk-summary-list.govuk-summary-list--no-border


### PR DESCRIPTION
Now that the supplier app uses ReportMI Frontend some missing styles
are available, we just needed to add the class name.

We also wrapped the summary list in a two-thirds column to keep it
from becoming too long.