### PR TITLE
(fix) Set the correct font for tables

### DIFF
--- a/app/assets/stylesheets/_settings.scss
+++ b/app/assets/stylesheets/_settings.scss
@@ -50,6 +50,7 @@ $govuk-colours: (
 
 // Typography
 $govuk-font-family: "Source Sans Pro", Helvetica, Arial, sans-serif;
+$govuk-font-family-tabular: "Source Sans Pro", Helvetica, Arial, sans-serif;
 $govuk-font-family-print: sans-serif;
 
 $govuk-font-weight-regular: 400;


### PR DESCRIPTION
When using govuk_table the $govuk-font-family-tabular must be set
to use the custom font setting, otherwise the default will be used.

Thanks to @leeky for the eagle-eyed spot!