### PR TITLE
(885) implement replacement returns design from ur analysis

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -29,5 +29,6 @@ class TasksController < ApplicationController
              .includes(:framework, :active_submission)
              .all
              .sort_by! { |t| Date.parse(t.due_on) }
+             .reverse!
   end
 end

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -36,10 +36,11 @@
             %a.govuk-link{:href => "https://www.surveymonkey.com/r/9QTDW9P"} feedback
             will help us to improve it.
 
+    .govuk-width-container
       %main{ role: 'main', id: 'main-content', class: 'govuk-main-wrapper'}
 
-      = render 'shared/alert' if flash[:alert]
+        = render 'shared/alert' if flash[:alert]
 
-      = yield
+        = yield
 
     = render 'shared/footer'

--- a/app/views/layouts/errors.html.haml
+++ b/app/views/layouts/errors.html.haml
@@ -36,10 +36,11 @@
             %a.govuk-link{:href => "https://www.surveymonkey.com/r/9QTDW9P"} feedback
             will help us to improve it.
 
+    .govuk-width-container
       %main{ role: 'main', id: 'main-content', class: 'govuk-main-wrapper'}
 
-      = render 'shared/alert' if flash[:alert]
+        = render 'shared/alert' if flash[:alert]
 
-      = yield
+        = yield
 
     = render 'shared/footer'

--- a/app/views/no_businesses/new.html.haml
+++ b/app/views/no_businesses/new.html.haml
@@ -1,7 +1,5 @@
 - page_title "Confirm report no business for #{@task.reporting_period} on #{@task.framework.short_name}"
 
-= render partial: 'shared/this_is_a_correction' if correction?
-
 .govuk-grid-row
   .govuk-grid-column-full
     = render 'shared/task_signpost', task: @task, action: 'Report no business for'
@@ -10,6 +8,8 @@
   .govuk-grid-column-full
     %h1.govuk-heading-xl
       Report no business
+
+    = render partial: 'shared/this_is_a_correction' if correction?
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds

--- a/app/views/shared/_alert.html.haml
+++ b/app/views/shared/_alert.html.haml
@@ -1,5 +1,5 @@
 .grid-row
   .column-full
-    .ccs-in_service_alert.ccs-in_service_alert--failure{:role => "alert", :tabindex =>"-1"}
+    .ccs-in-service-alert.ccs-in-service-alert--failure{:role => "alert", :tabindex =>"-1"}
       %h2.govuk-heading-s
         = flash[:alert]

--- a/app/views/shared/_submission_table.html.haml
+++ b/app/views/shared/_submission_table.html.haml
@@ -1,0 +1,24 @@
+%table.govuk-table
+  %caption.govuk-table__caption.govuk-visually-hidden
+    Submission
+  %thead.govuk-table__head
+    %tr.govuk-table__row
+      %th.govuk-table__header{ scope: 'col' } Submitted
+      %th.govuk-table__header.govuk-table__header--numeric{ scope: 'col' } Rows
+      %th.govuk-table__header.govuk-table__header--numeric{ scope: 'col' } Total
+
+  %tbody.govuk-table__body
+    %tr.govuk-table__row
+      %th.govuk-table__header{ scope: 'row' }
+        Contracts
+      %td.govuk-table__cell.govuk-table__cell--numeric
+        = @submission.order_count
+      %td.govuk-table__cell.govuk-table__cell--numeric
+        = number_to_currency(@submission.order_total_value, unit: '£')
+    %tr.govuk-table__row
+      %th.govuk-table__header{ scope: 'row' }
+        Invoices
+      %td.govuk-table__cell.govuk-table__cell--numeric
+        = submission.invoice_count
+      %td.govuk-table__cell.govuk-table__cell--numeric
+        = number_to_currency(@submission.invoice_total_value, unit: '£')

--- a/app/views/shared/_this_is_a_correction.html.haml
+++ b/app/views/shared/_this_is_a_correction.html.haml
@@ -1,2 +1,2 @@
-.ccs-in_service_alert.ccs-in_service_alert--notice{role: "alert"}
+.ccs-in-service-alert.ccs-in-service-alert--notice{role: "alert"}
   %h2.govuk-heading-s This is a correction.

--- a/app/views/submissions/completed.html.haml
+++ b/app/views/submissions/completed.html.haml
@@ -3,13 +3,14 @@
 - else
   - page_title "Task complete: Report management information for #{@task.reporting_period} on #{@task.framework.short_name}"
 
-= render partial: 'shared/this_is_a_correction' if correction?
-
 .govuk-grid-row
   .govuk-grid-column-two-thirds
     .govuk-panel.govuk-panel--confirmation
       %h1.govuk-panel__title
         Task complete
+
+      = render partial: 'shared/this_is_a_correction' if correction?
+
       .govuk-panel__body
         - if @submission.report_no_business?
           Thank you for reporting no business for

--- a/app/views/submissions/in_review.html.haml
+++ b/app/views/submissions/in_review.html.haml
@@ -1,7 +1,5 @@
 - page_title "Review & submit: Report management information for #{@task.reporting_period} on #{@task.framework.short_name}"
 
-= render partial: 'shared/this_is_a_correction' if correction?
-
 .govuk-grid-row
   .govuk-grid-column-full
     = render 'shared/task_signpost', task: @task
@@ -10,6 +8,8 @@
   .govuk-grid-column-full
     %h1.govuk-heading-xl
       Review & submit
+
+    = render partial: 'shared/this_is_a_correction' if correction?
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds

--- a/app/views/submissions/new.html.haml
+++ b/app/views/submissions/new.html.haml
@@ -1,6 +1,6 @@
 - page_title "Report management information for #{@task.reporting_period} on #{@task.framework.short_name}"
 
-= render partial: 'shared/this_is_a_correction' if correction?
+
 
 .govuk-grid-row
   .govuk-grid-column-full
@@ -10,6 +10,8 @@
   .govuk-grid-column-full
     %h1.govuk-heading-xl
       Report management information
+
+    = render partial: 'shared/this_is_a_correction' if correction?
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds

--- a/app/views/submissions/processing.html.haml
+++ b/app/views/submissions/processing.html.haml
@@ -1,7 +1,5 @@
 - page_title "Checking file: Report management information for #{@task.reporting_period} on #{@task.framework.short_name}"
 
-= render partial: 'shared/this_is_a_correction' if correction?
-
 = content_for(:head, tag.meta('http-equiv': 'refresh', content: 5))
 
 .govuk-grid-row
@@ -12,6 +10,8 @@
   .govuk-grid-column-full
     %h1.govuk-heading-l
       Checking file…
+
+      = render partial: 'shared/this_is_a_correction' if correction?
 
   = render 'shared/progress_indicator'
 

--- a/app/views/tasks/correct.html.haml
+++ b/app/views/tasks/correct.html.haml
@@ -43,7 +43,7 @@
           = link_to 'Report no business', new_task_no_business_path(@task, correction: true), class: 'govuk-button'
     .govuk-grid-row
       .govuk-grid-column-full
-        = link_to 'Report management information', new_task_submission_path(@task, correction: true), class: 'govuk-button'
+        = link_to 'Correct this return', new_task_submission_path(@task, correction: true), class: 'govuk-button'
 
     %h2.govuk-heading-m
       Incorrect return

--- a/app/views/tasks/correct.html.haml
+++ b/app/views/tasks/correct.html.haml
@@ -1,3 +1,5 @@
+- page_title "#{@task.framework.short_name} #{@task.framework.name} for #{@task.reporting_period} Correction "
+
 .govuk-grid-row
   .govuk-grid-column-full
     = link_to 'Back', history_tasks_path, { class: 'govuk-back-link', title: 'Back to your task history' }
@@ -6,7 +8,8 @@
   .govuk-grid-column-full
     %h1.govuk-heading-xl
       Correction
-
+.govuk-grid-row
+  .govuk-grid-column-two-thirds
     %dl.govuk-summary-list.govuk-summary-list--no-border
       .govuk-summary-list__row
         %dt.govuk-summary-list__key
@@ -21,12 +24,6 @@
         %dd.govuk-summary-list__value
           = @task.reporting_period
 
-      .govuk-summary-list__row
-        %dt.govuk-summary-list__key
-          Reported
-        %dd.govuk-summary-list__value
-          = @task.completed_at
-
       - if current_user.multiple_suppliers?
         .govuk-summary-list__row
           %dt.govuk-summary-list__key
@@ -37,50 +34,52 @@
     %p
       You will need to pay the management charge from the incorrect return unless a successful corrected return is made.
 
-    - unless @submission.report_no_business?
-      .govuk-grid-row
-        .govuk-grid-column-full
-          = link_to 'Report no business', new_task_no_business_path(@task, correction: true), class: 'govuk-button'
-    .govuk-grid-row
-      .govuk-grid-column-full
-        = link_to 'Correct this return', new_task_submission_path(@task, correction: true), class: 'govuk-button'
+.govuk-grid-row
+  .govuk-grid-column-full
 
-    %h2.govuk-heading-m
+    %hr.govuk-section-break.govuk-section-break--l
+
+    = link_to 'Correct this return', new_task_submission_path(@task, correction: true), class: ['govuk-button', 'govuk-!-margin-right-6']
+    - unless @submission.report_no_business?
+      = link_to 'Report no business', new_task_no_business_path(@task, correction: true), class: 'govuk-button'
+.govuk-grid-row
+  .govuk-grid-column-full
+    %hr.govuk-section-break.govuk-section-break--l.govuk-section-break--visible
+.govuk-grid-row
+  .govuk-grid-column-full
+    %h2.govuk-heading-l
       Incorrect return
 
-    - if @submission.report_no_business?
-      %p
+- if @submission.report_no_business?
+  .govuk-grid-row
+    .govuk-grid-column-full
+      %p.ccs-return.ccs-return--no-business
         You reported no business
-    - else
+- else
+  .govuk-grid-row
+    .govuk-grid-column-three-quarters
       %dl.govuk-summary-list.govuk-summary-list--no-border
+        .govuk-summary-list__row
+          %dt.govuk-summary-list__key
+            Reported
+          %dd.govuk-summary-list__value
+            = @task.completed_at
         - if @submission.purchase_order_number.present?
           .govuk-summary-list__row
             %dt.govuk-summary-list__key
               Purchase order number
             %dd.govuk-summary-list__value
               = @submission.purchase_order_number
+        .govuk-summary-list__row
+          %dt.govuk-summary-list__key
+            Filename
+          %dd.govuk-summary-list__value
+            = link_to(@file.filename, download_task_submission_path(@task, @submission))
 
-      %table.govuk-table
-        %thead.govuk-table__head
-          %tr.govuk-table__row
-            %th.govuk-table__header{ scope: 'col' } Filename
-            %th.govuk-table__header.govuk-table__header--numeric{ scope: 'col' } Invoices
-            %th.govuk-table__header.govuk-table__header--numeric{ scope: 'col' } Contracts
 
-        %tbody.govuk-table__body
-          %tr.govuk-table__row
-            %td.govuk-table__cell
-              = @file.filename
-            %td.govuk-table__cell.govuk-table__cell--numeric
-              = pluralize(@submission.invoice_count, 'row')
-            %td.govuk-table__cell.govuk-table__cell--numeric
-              = pluralize(@submission.order_count, 'row')
-          %tr.govuk-table__row
-            %td.govuk-table__cell
-            %td.govuk-table__cell.govuk-table__cell--numeric
-              = number_to_currency(@submission.invoice_total_value, unit: '£')
-            %td.govuk-table__cell.govuk-table__cell--numeric
-              = number_to_currency(@submission.order_total_value, unit: '£')
+  .govuk-grid-row
+    .govuk-grid-column-full
+      = render(partial: 'shared/submission_table', object: @submission, as: 'submission')
 
 .govuk-grid-row
   .govuk-grid-column-full

--- a/app/views/tasks/history.html.haml
+++ b/app/views/tasks/history.html.haml
@@ -1,25 +1,37 @@
 - page_title 'History'
-.govuk-grid-row
-  .govuk-grid-column-full
-    %h1.govuk-heading-xl
-      History
 
 - if @tasks.blank?
-  %p You have no completed tasks yet.
+  .govuk-grid-row
+    .govuk-grid-column-full
+      %h1.govuk-heading-xl
+        History
+      %p You have no completed tasks yet.
+
 - else
   .govuk-grid-row
     .govuk-grid-column-full
-      %table.govuk-table{:class => 'govuk-!-margin-top-7'}
+      %table.govuk-table
+        %caption.govuk-table__caption.govuk-heading-xl
+          History
         %thead.govuk-table__head
           %tr.govuk-table__row
             %th.govuk-table__header Framework
+            - if current_user.multiple_suppliers?
+              %th.govuk-table__header
+                Supplier
             %th.govuk-table__header Month
-            %th.govuk-table__header Reported
             %th.govuk-table__header Actions
         %tbody.govuk-table__body
           - @tasks.each do |task|
             %tr.govuk-table__row
-              %td.govuk-table__cell= task.framework.name
-              %td.govuk-table__cell= task.reporting_period
-              %td.govuk-table__cell= task.completed_at
-              %td.govuk-table__cell= link_to 'View', task_path(task)
+              %td.govuk-table__cell.ccs-report-table__cell
+                %h2= task.framework.name
+                %p.govuk-body-s
+                  = task.completed_at
+              - if current_user.multiple_suppliers?
+                %td.govuk-table__cell.ccs-report-table__cell
+                  = task.supplier_name
+              %td.govuk-table__cell.ccs-report-table__cell
+                = task.reporting_period
+              %td.govuk-table__cell.ccs-report-table__cell
+                = link_to 'View', task_path(task)

--- a/app/views/tasks/show.html.haml
+++ b/app/views/tasks/show.html.haml
@@ -1,3 +1,5 @@
+- page_title "#{@task.framework.short_name} #{@task.framework.name} for #{@task.reporting_period}"
+
 .govuk-grid-row
   .govuk-grid-column-full
     = link_to 'Back', history_tasks_path, { class: 'govuk-back-link', title: 'Back to your task history' }
@@ -8,7 +10,7 @@
       Task
 
 .govuk-grid-row
-  .govuk-grid-column-two-thirds
+  .govuk-grid-column-three-quarters
     %dl.govuk-summary-list.govuk-summary-list--no-border
       .govuk-summary-list__row
         %dt.govuk-summary-list__key
@@ -36,45 +38,35 @@
           %dd.govuk-summary-list__value
             = @task.supplier_name
 
+      - if @submission.purchase_order_number.present?
+        .govuk-summary-list__row
+          %dt.govuk-summary-list__key
+            Purchase order number
+          %dd.govuk-summary-list__value
+            = @submission.purchase_order_number
+
+      - if !@submission.report_no_business?
+        .govuk-summary-list__row
+          %dt.govuk-summary-list__key
+            Filename
+          %dd.govuk-summary-list__value
+            = link_to(@file.filename, download_task_submission_path(@task, @submission))
+
 .govuk-grid-row
   .govuk-grid-column-full
-    %h2.govuk-heading-m
-      Submitted management information
-
     - if @submission.report_no_business?
       %p.ccs-return.ccs-return--no-business
         You reported no business
     - else
-      %dl.govuk-summary-list.govuk-summary-list--no-border
-        - if @submission.purchase_order_number.present?
-          .govuk-summary-list__row
-            %dt.govuk-summary-list__key
-              Purchase order number
-            %dd.govuk-summary-list__value
-              = @submission.purchase_order_number
+      = render(partial: 'shared/submission_table', object: @submission, as: 'submission')
 
-      %table.govuk-table
-        %thead.govuk-table__head
-          %tr.govuk-table__row
-            %th.govuk-table__header{ scope: 'col' } Filename
-            %th.govuk-table__header.govuk-table__header--numeric{ scope: 'col' } Invoices
-            %th.govuk-table__header.govuk-table__header--numeric{ scope: 'col' } Contracts
-        %tbody.govuk-table__body
-          %tr.govuk-table__row
-            %td.govuk-table__cell
-              = link_to(@file.filename, download_task_submission_path(@task, @submission))
-            %td.govuk-table__cell.govuk-table__cell--numeric
-              = pluralize(@submission.invoice_count, 'row')
-            %td.govuk-table__cell.govuk-table__cell--numeric
-              = pluralize(@submission.order_count, 'row')
-          %tr.govuk-table__row
-            %td.govuk-table__cell
-            %td.govuk-table__cell.govuk-table__cell--numeric
-              = number_to_currency(@submission.invoice_total_value, unit: '£')
-            %td.govuk-table__cell.govuk-table__cell--numeric
-              = number_to_currency(@submission.order_total_value, unit: '£')
+- if correction_returns_enabled?
+  .govuk-grid-row
+    .govuk-grid-column-full
+      %hr.govuk-section-break.govuk-section-break--l
 
-    - if correction_returns_enabled?
+  .govuk-grid-row
+    .govuk-grid-column-two-thirds
       %h2.govuk-heading-m
         If this looks incorrect
       %p
@@ -83,9 +75,7 @@
         - else
           You can replace this return with a corrected one or report no business.
 
-      .govuk-grid-row
-        .govuk-grid-column-full
-          = link_to 'Correct this return', correct_task_path(@task), { class: 'govuk-button' }
+      = link_to 'Correct this return', correct_task_path(@task), { class: 'govuk-button' }
 
 .govuk-grid-row
   .govuk-grid-column-full

--- a/spec/features/user_can_correct_submission_with_mi_return_spec.rb
+++ b/spec/features/user_can_correct_submission_with_mi_return_spec.rb
@@ -28,7 +28,7 @@ RSpec.feature 'Correcting a submission by reporting MI return' do
       expect(page).to have_content 'July 2018'
       expect(page).to_not have_content 'Bobs Cheese Shop'
 
-      click_on 'Report management information', exact: true
+      click_on 'Correct this return', exact: true
       expect(page).to have_content 'This is a correction'
 
       mock_create_submission = mock_create_submission_endpoint!

--- a/spec/requests/tasks_spec.rb
+++ b/spec/requests/tasks_spec.rb
@@ -121,8 +121,9 @@ RSpec.describe 'the tasks list' do
     end
 
     it 'shows details of the task and submission' do
-      expect(response.body).to include 'Submitted management information'
-      expect(response.body).to include '42 rows'
+      expect(response.body).to include 'Contracts'
+      expect(response.body).to include 'Invoices'
+      expect(response.body).to include '42'
       expect(response.body).to include '£12,345.67'
       expect(response.body).to include 'RM3786 MISO Data Template (August 2018).xls'
     end
@@ -138,7 +139,6 @@ RSpec.describe 'the tasks list' do
     end
 
     it 'shows details of the task and no business submission' do
-      expect(response.body).to include 'Submitted management information'
       expect(response.body).to include 'You reported no business'
     end
   end

--- a/spec/requests/tasks_spec.rb
+++ b/spec/requests/tasks_spec.rb
@@ -93,6 +93,7 @@ RSpec.describe 'the tasks list' do
   context 'when viewing task history' do
     before do
       mock_complete_tasks_endpoint!
+      mock_user_endpoint!
       stub_signed_in_user
       get history_tasks_path
     end


### PR DESCRIPTION
A number of changes we wanted to make based on user research:

- Changed history page design so that the reported date and reporting month are less confusing.
- 'Report management information' button label on correction view is now 'Correct this return'
- The submission summary table had changed design to be clearer and match the order of the templates, this has also been made into a shared partial for re-use throughout the app.
- The 'This is a correction' flash felt like it was in the wrong section of the app layout so has been moved down
- There is also a fix to the page layout and the alert flashes, the layout had some content in the wrong element and the flashes were using out of date class names.

Does not change the submission summary table on the in review view as this will require more work on the tests.

Trello card: https://trello.com/c/VuXfO7eI