### PR TITLE
Don't specify explicit platform for mini_racer gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ gem 'sass-rails', '~> 5.0'
 # Use Uglifier as compressor for JavaScript assets
 gem 'uglifier', '>= 1.3.0'
 # See https://github.com/rails/execjs#readme for more supported runtimes
-gem 'mini_racer', platforms: :ruby
+gem 'mini_racer'
 
 # Use CoffeeScript for .coffee assets and views
 gem 'coffee-rails', '~> 4.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -151,6 +151,8 @@ GEM
       faraday_middleware
     jwt (1.5.6)
     libv8 (6.7.288.46.1)
+    libv8 (6.7.288.46.1-x86_64-darwin-17)
+    libv8 (6.7.288.46.1-x86_64-darwin-18)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -345,6 +347,7 @@ GEM
 PLATFORMS
   ruby
   x86_64-darwin-17
+  x86_64-darwin-18
 
 DEPENDENCIES
   auth0


### PR DESCRIPTION
I don't believe there is anything that would require us to restrict the platforms for the mini_racer gem.

This was causing me problems when trying to bundle on OSX Mojave; bundler would try compile libv8 from source, rather than downloading the prebuilt binary that is available.