### PR TITLE
(916) Make changes to the submission in review view

### DIFF
--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -15,7 +15,8 @@ class SubmissionsController < ApplicationController
 
   def show
     @task = API::Task.includes(:framework).find(params[:task_id]).first
-    @submission = API::Submission.find(params[:id]).first
+    @submission = API::Submission.includes(:files).find(params[:id]).first
+    @file = @submission.files&.first
 
     render template_for_submission(@submission)
   end

--- a/app/views/submissions/in_review.html.haml
+++ b/app/views/submissions/in_review.html.haml
@@ -12,31 +12,33 @@
     = render partial: 'shared/this_is_a_correction' if correction?
 
 .govuk-grid-row
-  .govuk-grid-column-two-thirds
-%p
-  Your file has been checked and is ready to submit.
-- if @submission.purchase_order_number
-  %p.govuk-heading-s
-    Purchase order number:
-    = @submission.purchase_order_number
-%table.govuk-table
-  %thead.govuk-table__head
-    %tr.govuk-table__row
-      %th.govuk-table__cell Filename
-      %th.govuk-table__cell Invoices
-      %th.govuk-table__cell Orders
-  %tbody.govuk-table__body
-    %tr.govuk-table__row
-      %td.govuk-table__cell
-        Uploaded file
-      %td.govuk-table__cell
-        = @submission.invoice_count
-      %td.govuk-table__cell
-        = @submission.order_count
+  .govuk-grid-column-three-quarters
+    %p
+      Your file has been checked and is ready to submit.
 
-= form_tag(task_submission_complete_path(task_id: @task.id, submission_id: @submission.id, correction: params[:correction]), method: :post) do
-  .form-group
-    = submit_tag 'Submit management information', class: 'govuk-button'
+    %dl.govuk-summary-list.govuk-summary-list--no-border
+      - if @submission.purchase_order_number.present?
+        .govuk-summary-list__row
+          %dt.govuk-summary-list__key
+            Purchase order number
+          %dd.govuk-summary-list__value
+            = @submission.purchase_order_number
+      .govuk-summary-list__row
+        %dt.govuk-summary-list__key
+          File
+        %dd.govuk-summary-list__value
+          = link_to(@file.filename, download_task_submission_path(@task, @submission))
+
+.govuk-grid-row
+  .govuk-grid-column-full
+    = render(partial: 'shared/submission_table', object: @submission, as: 'submission')
+
+.govuk-grid-row
+  .govuk-grid-column-full
+    = form_tag(task_submission_complete_path(task_id: @task.id, submission_id: @submission.id, correction: params[:correction]), method: :post) do
+      .form-group
+        = submit_tag 'Submit management information', class: 'govuk-button'
+
 .govuk-grid-row
   .govuk-grid-column-two-thirds
     %p

--- a/spec/features/task_management_spec.rb
+++ b/spec/features/task_management_spec.rb
@@ -30,6 +30,11 @@ RSpec.feature 'task management' do
 
     expect(page).to have_content 'Review & submit'
 
+    expect(page).to have_link(
+      'example.xls',
+      href: download_task_submission_path(mock_task_id, mock_submission_id)
+    )
+
     mock_complete_submission_endpoint!
     mock_submission_completed_with_task_endpoint!
     mock_submission_completed_report_mi_endpoint!

--- a/spec/fixtures/mocks/submission_completed_no_business.json
+++ b/spec/fixtures/mocks/submission_completed_no_business.json
@@ -5,8 +5,11 @@
     "attributes": {
       "framework_id": "f87717d4-874a-43d9-b99f-c8cf2897b526",
       "supplier_id": "cd40ead8-67b5-4918-abf0-ab8937cd04ff",
+      "task_id": "2d98639e-5260-411f-a5ee-61847a2e067c",
       "invoice_count": 0,
       "order_count": 0,
+      "order_total_value": "0.0",
+      "invoices_total_value": "0.0",
       "purchase_order_number": null,
       "status": "completed",
       "report_no_business?": true

--- a/spec/fixtures/mocks/submission_completed_no_business.json
+++ b/spec/fixtures/mocks/submission_completed_no_business.json
@@ -13,6 +13,11 @@
       "purchase_order_number": null,
       "status": "completed",
       "report_no_business?": true
+    },
+    "relationships": {
+      "files": {
+        "data": []
+      }
     }
   }
 }

--- a/spec/fixtures/mocks/submission_completed_report_mi.json
+++ b/spec/fixtures/mocks/submission_completed_report_mi.json
@@ -13,7 +13,29 @@
       "purchase_order_number": null,
       "status": "completed",
       "report_no_business?": false
+    },
+    "relationships": {
+      "files": {
+        "data": [
+          {
+            "type": "submission_files",
+            "id": "8d0e4289-5fde-4faa-b78e-922846d8460a"
+          }
+        ]
+      }
     }
-  }
+  },
+  "included": [
+    {
+      "id": "8d0e4289-5fde-4faa-b78e-922846d8460a",
+      "type": "submission_files",
+      "attributes": {
+        "submission_id": "9a5ef62c-0781-4f80-8850-5793652b6b40",
+        "temporary_download_url": "http://s3.example.com/example.xls",
+        "filename": "example.xls",
+        "rows": 3
+      }
+    }
+  ]
 }
 

--- a/spec/fixtures/mocks/submission_completed_report_mi.json
+++ b/spec/fixtures/mocks/submission_completed_report_mi.json
@@ -5,11 +5,15 @@
     "attributes": {
       "framework_id": "f87717d4-874a-43d9-b99f-c8cf2897b526",
       "supplier_id": "cd40ead8-67b5-4918-abf0-ab8937cd04ff",
+      "task_id": "2d98639e-5260-411f-a5ee-61847a2e067c",
       "invoice_count": 2,
       "order_count": 1,
+      "order_total_value": "1000.0",
+      "invoices_total_value": "2000.0",
       "purchase_order_number": null,
       "status": "completed",
       "report_no_business?": false
     }
   }
 }
+

--- a/spec/fixtures/mocks/submission_completed_with_task.json
+++ b/spec/fixtures/mocks/submission_completed_with_task.json
@@ -5,8 +5,11 @@
     "attributes": {
       "framework_id": "f87717d4-874a-43d9-b99f-c8cf2897b526",
       "supplier_id": "cd40ead8-67b5-4918-abf0-ab8937cd04ff",
+      "task_id": "2d98639e-5260-411f-a5ee-61847a2e067c",
       "invoice_count": 2,
       "order_count": 1,
+      "order_total_value": "1000.0",
+      "invoices_total_value": "2000.0",
       "purchase_order_number": "PO123",
       "status": "completed"
     },

--- a/spec/fixtures/mocks/submission_errored.json
+++ b/spec/fixtures/mocks/submission_errored.json
@@ -19,7 +19,29 @@
       "invoices_total_value": "2000.0",
       "purchase_order_number": null,
       "status": "validation_failed"
+    },
+    "relationships": {
+      "files": {
+        "data": [
+          {
+            "type": "submission_files",
+            "id": "8d0e4289-5fde-4faa-b78e-922846d8460a"
+          }
+        ]
+      }
     }
-  }
+  },
+  "included": [
+    {
+      "id": "8d0e4289-5fde-4faa-b78e-922846d8460a",
+      "type": "submission_files",
+      "attributes": {
+        "submission_id": "9a5ef62c-0781-4f80-8850-5793652b6b40",
+        "temporary_download_url": "http://s3.example.com/example.xls",
+        "filename": "example.xls",
+        "rows": 3
+      }
+    }
+  ]
 }
 

--- a/spec/fixtures/mocks/submission_errored.json
+++ b/spec/fixtures/mocks/submission_errored.json
@@ -5,6 +5,7 @@
     "attributes": {
       "framework_id": "f87717d4-874a-43d9-b99f-c8cf2897b526",
       "supplier_id": "cd40ead8-67b5-4918-abf0-ab8937cd04ff",
+      "task_id": "2d98639e-5260-411f-a5ee-61847a2e067c",
       "sheet_errors": {
         "InvoicesRaised": [
           { "message": "Enter value, without commas or pound signs", "location": { "row": 1, "column": "Price per Unit" } },
@@ -14,8 +15,11 @@
       },
       "invoice_count": 2,
       "order_count": 1,
+      "order_total_value": "1000.0",
+      "invoices_total_value": "2000.0",
       "purchase_order_number": null,
       "status": "validation_failed"
     }
   }
 }
+

--- a/spec/fixtures/mocks/submission_pending.json
+++ b/spec/fixtures/mocks/submission_pending.json
@@ -5,8 +5,11 @@
     "attributes": {
       "framework_id": "f87717d4-874a-43d9-b99f-c8cf2897b526",
       "supplier_id": "cd40ead8-67b5-4918-abf0-ab8937cd04ff",
+      "task_id": "2d98639e-5260-411f-a5ee-61847a2e067c",
       "invoice_count": 0,
       "order_count": 0,
+      "order_total_value": "0.0",
+      "invoices_total_value": "0.0",
       "purchase_order_number": null,
       "status": "pending"
     },

--- a/spec/fixtures/mocks/submission_pending.json
+++ b/spec/fixtures/mocks/submission_pending.json
@@ -14,10 +14,26 @@
       "status": "pending"
     },
     "relationships": {
-      "entries": {
-        "data": []
+      "files": {
+        "data": [
+          {
+            "type": "submission_files",
+            "id": "8d0e4289-5fde-4faa-b78e-922846d8460a"
+          }
+        ]
       }
     }
   },
-  "included": []
+  "included": [
+    {
+      "id": "8d0e4289-5fde-4faa-b78e-922846d8460a",
+      "type": "submission_files",
+      "attributes": {
+        "submission_id": "9a5ef62c-0781-4f80-8850-5793652b6b40",
+        "temporary_download_url": "http://s3.example.com/example.xls",
+        "filename": "example.xls",
+        "rows": 3
+      }
+    }
+  ]
 }

--- a/spec/fixtures/mocks/submission_processing.json
+++ b/spec/fixtures/mocks/submission_processing.json
@@ -5,8 +5,11 @@
     "attributes": {
       "framework_id": "f87717d4-874a-43d9-b99f-c8cf2897b526",
       "supplier_id": "cd40ead8-67b5-4918-abf0-ab8937cd04ff",
+      "task_id": "2d98639e-5260-411f-a5ee-61847a2e067c",
       "invoice_count": 1,
       "order_count": 0,
+      "order_total_value": "0.0",
+      "invoices_total_value": "1000.0",
       "purchase_order_number": null,
       "status": "processing"
     }

--- a/spec/fixtures/mocks/submission_processing.json
+++ b/spec/fixtures/mocks/submission_processing.json
@@ -12,6 +12,28 @@
       "invoices_total_value": "1000.0",
       "purchase_order_number": null,
       "status": "processing"
+    },
+    "relationships": {
+      "files": {
+        "data": [
+          {
+            "type": "submission_files",
+            "id": "8d0e4289-5fde-4faa-b78e-922846d8460a"
+          }
+        ]
+      }
     }
-  }
+  },
+  "included": [
+    {
+      "id": "8d0e4289-5fde-4faa-b78e-922846d8460a",
+      "type": "submission_files",
+      "attributes": {
+        "submission_id": "9a5ef62c-0781-4f80-8850-5793652b6b40",
+        "temporary_download_url": "http://s3.example.com/example.xls",
+        "filename": "example.xls",
+        "rows": 3
+      }
+    }
+  ]
 }

--- a/spec/fixtures/mocks/submission_validated.json
+++ b/spec/fixtures/mocks/submission_validated.json
@@ -12,6 +12,28 @@
       "invoice_total_value": "2000.00",
       "purchase_order_number": "123",
       "status": "in_review"
+    },
+    "relationships": {
+      "files": {
+        "data": [
+          {
+            "type": "submission_files",
+            "id": "8d0e4289-5fde-4faa-b78e-922846d8460a"
+          }
+        ]
+      }
     }
-  }
+  },
+  "included": [
+    {
+      "id": "8d0e4289-5fde-4faa-b78e-922846d8460a",
+      "type": "submission_files",
+      "attributes": {
+        "submission_id": "9a5ef62c-0781-4f80-8850-5793652b6b40",
+        "temporary_download_url": "http://s3.example.com/example.xls",
+        "filename": "example.xls",
+        "rows": 3
+      }
+    }
+  ]
 }

--- a/spec/fixtures/mocks/submission_validated.json
+++ b/spec/fixtures/mocks/submission_validated.json
@@ -5,8 +5,11 @@
     "attributes": {
       "framework_id": "f87717d4-874a-43d9-b99f-c8cf2897b526",
       "supplier_id": "cd40ead8-67b5-4918-abf0-ab8937cd04ff",
+      "task_id": "2d98639e-5260-411f-a5ee-61847a2e067c",
       "invoice_count": 2,
       "order_count": 1,
+      "order_total_value": "1000.00",
+      "invoice_total_value": "2000.00",
       "purchase_order_number": "123",
       "status": "in_review"
     }

--- a/spec/fixtures/mocks/submission_with_file.json
+++ b/spec/fixtures/mocks/submission_with_file.json
@@ -5,6 +5,7 @@
     "attributes": {
       "framework_id": "f87717d4-874a-43d9-b99f-c8cf2897b526",
       "supplier_id": "cd40ead8-67b5-4918-abf0-ab8937cd04ff",
+      "task_id": "2d98639e-5260-411f-a5ee-61847a2e067c",
       "invoice_count": 2,
       "order_count": 1,
       "invoice_total_value": 123.45,

--- a/spec/support/api_helpers.rb
+++ b/spec/support/api_helpers.rb
@@ -38,32 +38,32 @@ module ApiHelpers
   end
 
   def mock_submission_pending_endpoint!
-    stub_request(:get, api_url("submissions/#{mock_submission_id}"))
+    stub_request(:get, api_url("submissions/#{mock_submission_id}?include=files"))
       .to_return(headers: json_headers, body: json_fixture_file('submission_pending.json'))
   end
 
   def mock_submission_processing_endpoint!
-    stub_request(:get, api_url("submissions/#{mock_submission_id}"))
+    stub_request(:get, api_url("submissions/#{mock_submission_id}?include=files"))
       .to_return(headers: json_headers, body: json_fixture_file('submission_processing.json'))
   end
 
   def mock_submission_validated_endpoint!
-    stub_request(:get, api_url("submissions/#{mock_submission_id}"))
+    stub_request(:get, api_url("submissions/#{mock_submission_id}?include=files"))
       .to_return(headers: json_headers, body: json_fixture_file('submission_validated.json'))
   end
 
   def mock_submission_errored_endpoint!
-    stub_request(:get, api_url("submissions/#{mock_submission_id}"))
+    stub_request(:get, api_url("submissions/#{mock_submission_id}?include=files"))
       .to_return(headers: json_headers, body: json_fixture_file('submission_errored.json'))
   end
 
   def mock_submission_completed_no_business_endpoint!
-    stub_request(:get, api_url("submissions/#{mock_submission_id}"))
+    stub_request(:get, api_url("submissions/#{mock_submission_id}?include=files"))
       .to_return(headers: json_headers, body: json_fixture_file('submission_completed_no_business.json'))
   end
 
   def mock_submission_completed_report_mi_endpoint!
-    stub_request(:get, api_url("submissions/#{mock_submission_id}"))
+    stub_request(:get, api_url("submissions/#{mock_submission_id}?include=files"))
       .to_return(headers: json_headers, body: json_fixture_file('submission_completed_report_mi.json'))
   end
 
@@ -73,7 +73,7 @@ module ApiHelpers
   end
 
   def mock_submission_transitioning_to_in_review!
-    stub_request(:get, api_url("submissions/#{mock_submission_id}"))
+    stub_request(:get, api_url("submissions/#{mock_submission_id}?include=files"))
       .to_return(headers: json_headers, body: json_fixture_file('submission_pending.json'))
       .then
       .to_return(headers: json_headers, body: json_fixture_file('submission_validated.json'))
@@ -202,7 +202,7 @@ module ApiHelpers
 
   def mock_create_submission_file_endpoint!
     submission_file = {
-      data:  {
+      data: {
         id: mock_submission_file_id,
         type: 'submission_files',
         attributes: {


### PR DESCRIPTION
- Use new partial for displaying a submission
- Include the submission files in the API request so that we can
display the file name and link to the file

Showing the file name meant we had to load the submission with the
files included from the API and that means all the mock API calls
had to be updated.

Before:

![Screenshot_2019-03-12_Review_submit_Report_management_information_for_August_2018_on_RM3786](https://user-images.githubusercontent.com/480578/54350612-96e83980-4645-11e9-8ea7-73a331ab69f8.png)

After: 

![Screenshot_2019-03-14 RM3786 General Legal Advice Services for February 2019](https://user-images.githubusercontent.com/480578/54350621-9e0f4780-4645-11e9-8dbd-49c44a57c35b.png)

Trello: https://trello.com/c/mtq34reF