### PR TITLE
(fix) Page title displays default value

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -3,7 +3,7 @@
   %head
     %meta{ content: 'text/html; charset=UTF-8', 'http-equiv': 'Content-Type' }/
     %title
-      = yield(:page_title) || 'Report management information to CCS'
+      = yield(:page_title).empty? ? 'Report management information to CCS' : yield(:page_title)
     %meta{ name: 'viewport', content: 'width=device-width, initial-scale=1' }/
     %meta{ 'http-equiv': 'x-ua-compatible', content: 'ie-edge' }/
     %meta{ name: 'format-detection', content: 'telephone=no' }/


### PR DESCRIPTION
The <title> tag was not getting the default value of 'Report management
information to CCS'. The yield seems to return an empty string object so
is always true.