### PR TITLE
Remove unnecessary JS-related dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,11 +16,9 @@ gem 'uglifier', '>= 1.3.0'
 # See https://github.com/rails/execjs#readme for more supported runtimes
 gem 'mini_racer'
 
-# Use CoffeeScript for .coffee assets and views
-gem 'coffee-rails', '~> 4.2'
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 gem 'jbuilder', '~> 2.5'
-gem 'jquery-rails'
+
 # Use ActiveModel has_secure_password
 # gem 'bcrypt', '~> 3.1.7'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -79,13 +79,6 @@ GEM
     climate_control (0.2.0)
     cliver (0.3.2)
     coderay (1.1.2)
-    coffee-rails (4.2.2)
-      coffee-script (>= 2.2.0)
-      railties (>= 4.0.0)
-    coffee-script (2.4.1)
-      coffee-script-source
-      execjs
-    coffee-script-source (1.12.2)
     concurrent-ruby (1.1.5)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
@@ -139,10 +132,6 @@ GEM
       activesupport (>= 4.2.0)
       multi_json (>= 1.2)
     jmespath (1.4.0)
-    jquery-rails (4.3.3)
-      rails-dom-testing (>= 1, < 3)
-      railties (>= 4.2.0)
-      thor (>= 0.14, < 2.0)
     jsonapi-consumer (1.0.1)
       activemodel (>= 3.2)
       activesupport (>= 3.2)
@@ -357,14 +346,12 @@ DEPENDENCIES
   byebug
   capybara
   climate_control
-  coffee-rails (~> 4.2)
   database_cleaner
   dotenv-rails
   factory_bot_rails
   haml-rails
   httparty
   jbuilder (~> 2.5)
-  jquery-rails
   jsonapi-consumer (~> 1.0)
   listen (>= 3.0.5, < 3.2)
   lograge

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -11,7 +11,6 @@
 // about supported directives.
 //
 //= require rails-ujs
-//= require jquery
 //= require activestorage
 //= require govuk-frontend/all.js
 //= require_tree .


### PR DESCRIPTION
We don't use JQuery in any JavaScript (and it's no longer a depency of Rails since UJS is written in pure JavaScript as of Rails v5.1), plus we don't have any CoffeeScript either.