### PR TITLE
(818) Incomplete correction submission

### DIFF
--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -57,7 +57,11 @@ class SubmissionsController < ApplicationController
                       .merge(file_id: submission_file.id)
 
     API::SubmissionFileBlob.create(blob_attributes)
-    task.update(status: 'in_progress') unless correction?
+    if correction?
+      task.update(status: 'correcting')
+    else
+      task.update(status: 'in_progress')
+    end
 
     submission
   end

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -31,4 +31,13 @@ class TasksController < ApplicationController
              .sort_by! { |t| Date.parse(t.due_on) }
              .reverse!
   end
+
+  def cancel_correction
+    @task = API::Task.find(params[:id]).first
+    @task.cancel_correction
+    redirect_to(
+      task_path(@task),
+      flash: { notice: 'You have successfully cancelled the correction.' }
+    )
+  end
 end

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -32,8 +32,16 @@ class TasksController < ApplicationController
              .reverse!
   end
 
+  def cancel_correction_confirmation
+    @task = API::Task.includes(:framework).find(params[:id]).first
+
+    redirect_to root_path unless @task.correcting?
+  end
+
   def cancel_correction
     @task = API::Task.find(params[:id]).first
+    redirect_to root_path unless @task.correcting?
+
     @task.cancel_correction
     redirect_to(
       task_path(@task),

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -2,8 +2,8 @@ class TasksController < ApplicationController
   def index
     @tasks = API::Task
              .select(submissions: %i[status submitted_at])
-             .where(status: ['unstarted', 'in_progress'])
-             .includes(:framework, :active_submission)
+             .where(status: ['unstarted', 'in_progress', 'correcting'])
+             .includes(:framework, :active_submission, :latest_submission)
              .all
              .sort_by! { |t| Date.parse(t.due_on) }
   end

--- a/app/models/api/task.rb
+++ b/app/models/api/task.rb
@@ -2,6 +2,7 @@ module API
   class Task < Base
     has_one :framework
     has_one :active_submission, class_name: 'API::Submission'
+    has_one :latest_submission, class_name: 'API::Submission'
 
     custom_endpoint :no_business, on: :member, request_method: :post
 
@@ -15,6 +16,10 @@ module API
 
     def late?
       !complete? && due_on.to_date < Time.zone.today
+    end
+
+    def correcting?
+      status == 'correcting'
     end
 
     def reporting_period

--- a/app/models/api/task.rb
+++ b/app/models/api/task.rb
@@ -5,6 +5,7 @@ module API
     has_one :latest_submission, class_name: 'API::Submission'
 
     custom_endpoint :no_business, on: :member, request_method: :post
+    custom_endpoint :cancel_correction, on: :member, request_method: :patch
 
     def complete?
       status == 'completed'

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -41,6 +41,8 @@
 
         = render 'shared/alert' if flash[:alert]
 
+        = render 'shared/notice' if flash[:notice]
+
         = yield
 
     = render 'shared/footer'

--- a/app/views/shared/_notice.html.haml
+++ b/app/views/shared/_notice.html.haml
@@ -1,0 +1,5 @@
+.grid-row
+  .column-full
+    .ccs-in-service-alert.ccs-in-service-alert--success{role: 'alert'}
+      %h2.govuk-heading-s
+        = flash[:notice]

--- a/app/views/tasks/_task.html.haml
+++ b/app/views/tasks/_task.html.haml
@@ -31,7 +31,7 @@
     .ccs-task__action--secondary
       %p
         - if task.correcting?
-          = link_to 'Cancel correction', cancel_correction_task_path(task), method: :patch
+          = link_to 'Cancel correction', cancel_correction_confirmation_task_path(task)
         - else
           = link_to 'Download template', task_template_path(task), {'aria-label' => "Download template for #{task.framework.short_name} #{task.framework.name}"}
     .ccs-task__action--primary

--- a/app/views/tasks/_task.html.haml
+++ b/app/views/tasks/_task.html.haml
@@ -7,6 +7,8 @@
         %strong.govuk-tag.govuk-tag__failure Errors
       - if task.late?
         %strong.govuk-tag.govuk-tag__warning Late
+      - if task.correcting?
+        %strong.govuk-tag.govuk-tag__notice Correction
     .ccs-task__body
       %h2.govuk-heading-s
         Report management information for
@@ -33,6 +35,8 @@
       - case task.status
       - when 'in_progress'
         = render 'submission_buttons', task: task, submission: task.active_submission
+      - when 'correcting'
+        = render 'submission_buttons', task: task, submission: task.latest_submission
       - when 'unstarted'
         = link_to 'Report management information', new_task_submission_path(task_id: task.id),  {class: 'govuk-button', 'aria-label' => "Report management information for #{task.supplier_name} on #{task.framework.short_name}"}
         = link_to 'Report no business', new_task_no_business_path(task_id: task.id), {class: 'govuk-button', 'aria-label' => "Report no business for #{task.supplier_name} on #{task.framework.short_name}"}

--- a/app/views/tasks/_task.html.haml
+++ b/app/views/tasks/_task.html.haml
@@ -30,7 +30,10 @@
   .ccs-task__action
     .ccs-task__action--secondary
       %p
-        = link_to 'Download template', task_template_path(task), {'aria-label' => "Download template for #{task.framework.short_name} #{task.framework.name}"}
+        - if task.correcting?
+          = link_to 'Cancel correction', cancel_correction_task_path(task), method: :patch
+        - else
+          = link_to 'Download template', task_template_path(task), {'aria-label' => "Download template for #{task.framework.short_name} #{task.framework.name}"}
     .ccs-task__action--primary
       - case task.status
       - when 'in_progress'

--- a/app/views/tasks/cancel_correction_confirmation.html.haml
+++ b/app/views/tasks/cancel_correction_confirmation.html.haml
@@ -1,0 +1,23 @@
+- page_title "#{@task.framework.short_name} #{@task.framework.name} for #{@task.reporting_period} Correction "
+
+.govuk-grid-row
+  .govuk-grid-column-full
+    = link_to 'Back', tasks_path, { class: 'govuk-back-link', title: 'Back to your tasks' }
+
+.govuk-grid-row
+  .govuk-grid-column-full
+    %h1.govuk-heading-xl
+      Confirm correction cancellation
+
+.govuk-grid-row
+  .govuk-grid-column-full
+    %p
+      By cancelling this correction you will still be required to pay the management charge from the existing submission you made.
+    %p
+      Any correction files uploaded will be deleted.
+
+.govuk-grid-row
+  .govuk-grid-column-full
+    = form_tag cancel_correction_task_path(task_id: @task.id), method: :patch do
+      .form-group
+        = submit_tag 'Cancel correction', data: { 'prevent-double-click': true }, class: 'govuk-button'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,7 @@ Rails.application.routes.draw do
     end
     member do
       get :correct
+      patch :cancel_correction
     end
     resources :submissions, only: %i[new create show] do
       member do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,7 @@ Rails.application.routes.draw do
     end
     member do
       get :correct
+      get :cancel_correction_confirmation
       patch :cancel_correction
     end
     resources :submissions, only: %i[new create show] do

--- a/spec/features/user_can_cancel_correction_spec.rb
+++ b/spec/features/user_can_cancel_correction_spec.rb
@@ -1,0 +1,40 @@
+require 'rails_helper'
+
+RSpec.feature 'Cancelling a correction submission' do
+  around(:each) do |example|
+    ClimateControl.modify CORRECTION_RETURNS_ENABLED: 'yes' do
+      example.run
+    end
+  end
+
+  context 'for a task with a correction in progress' do
+    scenario 'it can be cancelled' do
+      visit '/'
+
+      mock_user_endpoint!
+      mock_sso_with(email: 'email@example.com')
+      mock_incomplete_tasks_endpoint!
+      click_link 'sign-in'
+
+      mock_correcting_task_with_framework_endpoint!
+      click_link 'Cancel correction'
+      mock_correcting_task_endpoint!
+      mock_correction_cancellation = mock_correction_cancellation_endpoint!
+      mock_correcting_task_with_framework_and_active_submission_endpoint!
+      click_button 'Cancel correction'
+
+      expect(mock_correction_cancellation).to have_been_requested
+      expect(current_path).to eq(task_path('b847e0f7-027e-4b95-afa2-3490b8d05a1d'))
+      expect(page).to have_content('You have successfully cancelled the correction.')
+    end
+  end
+
+  context 'for a task that is not a correction' do
+    it 'redirects to home page' do
+      mock_task_with_framework_endpoint!
+
+      visit cancel_correction_confirmation_task_path('2d98639e-5260-411f-a5ee-61847a2e067c')
+      expect(current_path).to eq(root_path)
+    end
+  end
+end

--- a/spec/features/user_can_correct_submission_with_mi_return_spec.rb
+++ b/spec/features/user_can_correct_submission_with_mi_return_spec.rb
@@ -35,13 +35,16 @@ RSpec.feature 'Correcting a submission by reporting MI return' do
       mock_create_submission_file_endpoint!
       mock_create_submission_file_blob_endpoint!
       mock_submission_transitioning_to_in_review!
-      mock_update_task_endpoint!
+      mock_update_task_in_progress = mock_update_task_endpoint!
+      mock_update_task_correcting = mock_update_task_endpoint!(status: 'correcting')
       attach_file 'upload', Rails.root.join('spec', 'fixtures', 'uploads', 'empty.xlsx')
       click_button 'Upload'
       expect(page).to have_content 'This is a correction'
       expect(page).to have_content 'Checking file'
 
       expect(mock_create_submission.with(hash_including_correction)).to have_been_requested
+      expect(mock_update_task_in_progress).to_not have_been_requested
+      expect(mock_update_task_correcting).to have_been_requested
 
       visit page.current_url
       expect(page).to have_content 'Review & submit'

--- a/spec/fixtures/mocks/correcting_task.json
+++ b/spec/fixtures/mocks/correcting_task.json
@@ -1,0 +1,106 @@
+{
+  "data": {
+    "id": "b847e0f7-027e-4b95-afa2-3490b8d05a1d",
+    "type": "tasks",
+    "attributes": {
+      "description": null,
+      "due_on": "2030-01-01",
+      "period_month": 7,
+      "period_year": 2018,
+      "status": "correcting",
+      "framework_id": "f87717d4-874a-43d9-b99f-c8cf2897b526",
+      "supplier_id": "cd40ead8-67b5-4918-abf0-ab8937cd04ff",
+      "supplier_name": "Bobs Cheese Shop"
+    },
+    "relationships": {
+      "framework": {
+        "data": {
+          "type": "frameworks",
+          "id": "f87717d4-874a-43d9-b99f-c8cf2897b526"
+        }
+      },
+      "active_submission": {
+        "data": {
+          "type": "submissions",
+          "id": "9a5ef62c-0781-4f80-8850-5793652b6b40"
+        }
+      },
+      "latest_submission": {
+        "data": {
+          "type": "submissions",
+          "id": "9a5ef62c-0781-4f80-8850-5793652b6b41"
+        }
+      }
+    }
+  },
+  "included": [
+    {
+      "id": "f87717d4-874a-43d9-b99f-c8cf2897b526",
+      "type": "frameworks",
+      "attributes": {
+        "short_name": "CBOARD5",
+        "name": "Cheese Board 5"
+      }
+    },
+    {
+      "id": "9a5ef62c-0781-4f80-8850-5793652b6b40",
+      "type": "submissions",
+      "attributes": {
+        "framework_id": "485c9fdd-cfc9-4b3c-9a69-a8195f9c13bc",
+        "supplier_id": "533a1357-4faf-4ced-b759-3e6da0bc5f3e",
+        "task_id": "141ccb6c-b5cb-4b05-9931-bd71d9ec3d96",
+        "report_no_business?": false,
+        "status": "completed",
+        "submitted_at": "2019-02-14T15:39:38.151Z",
+        "purchase_order_number": "PO123",
+        "invoice_count": 42,
+        "order_count": 99,
+        "invoice_total_value": 12345.67,
+        "order_total_value": 987.65
+      },
+      "relationships": {
+        "files": {
+          "data": {
+            "type": "submission_files",
+            "id": "8f62dc3a-4765-48d0-9544-e850ff8c3b80"
+          }
+        }
+      }
+    },
+    {
+      "id": "9a5ef62c-0781-4f80-8850-5793652b6b41",
+      "type": "submissions",
+      "attributes": {
+        "framework_id": "485c9fdd-cfc9-4b3c-9a69-a8195f9c13bc",
+        "supplier_id": "533a1357-4faf-4ced-b759-3e6da0bc5f3e",
+        "task_id": "141ccb6c-b5cb-4b05-9931-bd71d9ec3d96",
+        "report_no_business?": false,
+        "status": "in_review",
+        "submitted_at": "2019-02-15T15:39:38.151Z",
+        "purchase_order_number": "PO123",
+        "invoice_count": 42,
+        "order_count": 99,
+        "invoice_total_value": 12345.67,
+        "order_total_value": 987.65
+      },
+      "relationships": {
+        "files": {
+          "data": {
+            "type": "submission_files",
+            "id": "8f62dc3a-4765-48d0-9544-e850ff8c3b80"
+          }
+        }
+      }
+    },
+    {
+      "id": "8f62dc3a-4765-48d0-9544-e850ff8c3b80",
+      "type": "submission_files",
+      "attributes": {
+        "submission_id": "9a5ef62c-0781-4f80-8850-5793652b6b40",
+        "rows": 6,
+        "filename": "RM3786 MISO Data Template (August 2018).xls",
+        "temporary_download_url": "https://s3.example.com/example.xls"
+      }
+    }
+  ]
+}

--- a/spec/fixtures/mocks/correcting_task_with_framework.json
+++ b/spec/fixtures/mocks/correcting_task_with_framework.json
@@ -1,0 +1,34 @@
+{
+  "data": {
+    "id": "b847e0f7-027e-4b95-afa2-3490b8d05a1d",
+    "type": "tasks",
+    "attributes": {
+      "description": null,
+      "due_on": "2030-01-01",
+      "period_month": 7,
+      "period_year": 2018,
+      "status": "correcting",
+      "framework_id": "f87717d4-874a-43d9-b99f-c8cf2897b526",
+      "supplier_id": "cd40ead8-67b5-4918-abf0-ab8937cd04ff",
+      "supplier_name": "Bobs Cheese Shop"
+    },
+    "relationships": {
+      "framework": {
+        "data": {
+          "type": "frameworks",
+          "id": "f87717d4-874a-43d9-b99f-c8cf2897b526"
+        }
+      }
+    }
+  },
+  "included": [
+    {
+      "id": "f87717d4-874a-43d9-b99f-c8cf2897b526",
+      "type": "frameworks",
+      "attributes": {
+        "short_name": "CBOARD5",
+        "name": "Cheese Board 5"
+      }
+    }
+  ]
+}

--- a/spec/fixtures/mocks/correcting_task_with_framework_and_active_submission.json
+++ b/spec/fixtures/mocks/correcting_task_with_framework_and_active_submission.json
@@ -1,0 +1,75 @@
+{
+  "data": {
+    "id": "b847e0f7-027e-4b95-afa2-3490b8d05a1d",
+    "type": "tasks",
+    "attributes": {
+      "description": null,
+      "due_on": "2030-01-01",
+      "period_month": 7,
+      "period_year": 2018,
+      "status": "correcting",
+      "framework_id": "f87717d4-874a-43d9-b99f-c8cf2897b526",
+      "supplier_id": "cd40ead8-67b5-4918-abf0-ab8937cd04ff",
+      "supplier_name": "Bobs Cheese Shop"
+    },
+    "relationships": {
+      "active_submission": {
+        "data": {
+          "type": "submissions",
+          "id": "9a5ef62c-0781-4f80-8850-5793652b6b40"
+        }
+      },
+      "framework": {
+        "data": {
+          "type": "frameworks",
+          "id": "f87717d4-874a-43d9-b99f-c8cf2897b526"
+        }
+      }
+    }
+  },
+  "included": [
+    {
+      "id": "f87717d4-874a-43d9-b99f-c8cf2897b526",
+      "type": "frameworks",
+      "attributes": {
+        "short_name": "CBOARD5",
+        "name": "Cheese Board 5"
+      }
+    },
+    {
+      "id": "9a5ef62c-0781-4f80-8850-5793652b6b40",
+      "type": "submissions",
+      "attributes": {
+        "framework_id": "485c9fdd-cfc9-4b3c-9a69-a8195f9c13bc",
+        "supplier_id": "533a1357-4faf-4ced-b759-3e6da0bc5f3e",
+        "task_id": "141ccb6c-b5cb-4b05-9931-bd71d9ec3d96",
+        "report_no_business?": false,
+        "status": "completed",
+        "submitted_at": "2019-02-14T15:39:38.151Z",
+        "purchase_order_number": "PO123",
+        "invoice_count": 42,
+        "order_count": 99,
+        "invoice_total_value": 12345.67,
+        "order_total_value": 987.65
+      },
+      "relationships": {
+        "files": {
+          "data": {
+            "type": "submission_files",
+            "id": "8f62dc3a-4765-48d0-9544-e850ff8c3b80"
+          }
+        }
+      }
+    },
+    {
+      "id": "8f62dc3a-4765-48d0-9544-e850ff8c3b80",
+      "type": "submission_files",
+      "attributes": {
+        "submission_id": "9a5ef62c-0781-4f80-8850-5793652b6b40",
+        "rows": 6,
+        "filename": "RM3786 MISO Data Template (August 2018).xls",
+        "temporary_download_url": "https://s3.example.com/example.xls"
+      }
+    }
+  ]
+}

--- a/spec/fixtures/mocks/incomplete_tasks_with_framework_and_active_submission.json
+++ b/spec/fixtures/mocks/incomplete_tasks_with_framework_and_active_submission.json
@@ -17,6 +17,9 @@
         "active_submission": {
           "data": null
         },
+        "latest_submission": {
+          "data": null
+        },
         "submissions": {
           "meta": {
             "included": false
@@ -45,6 +48,12 @@
       },
       "relationships": {
         "active_submission": {
+          "data": {
+            "type": "submissions",
+            "id": "63996088-5c20-4e65-b722-287fafeedc97"
+          }
+        },
+        "latest_submission": {
           "data": {
             "type": "submissions",
             "id": "63996088-5c20-4e65-b722-287fafeedc97"
@@ -83,6 +92,12 @@
             "id": "65b11138-8c7e-4427-93a2-c5da3a7c3f9d"
           }
         },
+        "latest_submission": {
+          "data": {
+            "type": "submissions",
+            "id": "65b11138-8c7e-4427-93a2-c5da3a7c3f9d"
+          }
+        },
         "submissions": {
           "meta": {
             "included": false
@@ -111,6 +126,12 @@
       },
       "relationships": {
         "active_submission": {
+          "data": {
+            "type": "submissions",
+            "id": "67e7a34f-5d4c-4946-b045-da77f4b651db"
+          }
+        },
+        "latest_submission": {
           "data": {
             "type": "submissions",
             "id": "67e7a34f-5d4c-4946-b045-da77f4b651db"
@@ -147,6 +168,51 @@
           "data": {
             "type": "submissions",
             "id": "43dfbd10-1c17-4f3c-8665-be8c2776249b"
+          }
+        },
+        "latest_submission": {
+          "data": {
+            "type": "submissions",
+            "id": "43dfbd10-1c17-4f3c-8665-be8c2776249b"
+          }
+        },
+        "submissions": {
+          "meta": {
+            "included": false
+          }
+        },
+        "framework": {
+          "data": {
+            "type": "frameworks",
+            "id": "7a50a178-3fb8-4c0a-9f2c-8841812448d1"
+          }
+        }
+      }
+    },
+    {
+      "id": "b847e0f7-027e-4b95-afa2-3490b8d05a1d",
+      "type": "tasks",
+      "attributes": {
+        "status": "correcting",
+        "framework_id": "7a50a178-3fb8-4c0a-9f2c-8841812448d1",
+        "supplier_id": "533a1357-4faf-4ced-b759-3e6da0bc5f3e",
+        "supplier_name": "Bobs Cheese Shop",
+        "description": null,
+        "due_on": "2017-08-07",
+        "period_year": 2017,
+        "period_month": 7
+      },
+      "relationships": {
+        "active_submission": {
+          "data": {
+            "type": "submissions",
+            "id": "43dfbd10-1c17-4f3c-8665-be8c27762999"
+          }
+        },
+        "latest_submission": {
+          "data": {
+            "type": "submissions",
+            "id": "43dfbd10-1c17-4f3c-8665-be8c27762923"
           }
         },
         "submissions": {
@@ -291,6 +357,66 @@
       "type": "submissions",
       "attributes": {
         "status": "validation_failed",
+        "submitted_at": null
+      },
+      "relationships": {
+        "framework": {
+          "meta": {
+            "included": false
+          }
+        },
+        "task": {
+          "meta": {
+            "included": false
+          }
+        },
+        "entries": {
+          "meta": {
+            "included": false
+          }
+        },
+        "files": {
+          "meta": {
+            "included": false
+          }
+        }
+      }
+    },
+    {
+      "id": "43dfbd10-1c17-4f3c-8665-be8c27762923",
+      "type": "submissions",
+      "attributes": {
+        "status": "validation_failed",
+        "submitted_at": null
+      },
+      "relationships": {
+        "framework": {
+          "meta": {
+            "included": false
+          }
+        },
+        "task": {
+          "meta": {
+            "included": false
+          }
+        },
+        "entries": {
+          "meta": {
+            "included": false
+          }
+        },
+        "files": {
+          "meta": {
+            "included": false
+          }
+        }
+      }
+    },
+    {
+      "id": "43dfbd10-1c17-4f3c-8665-be8c27762999",
+      "type": "submissions",
+      "attributes": {
+        "status": "completed",
         "submitted_at": null
       },
       "relationships": {

--- a/spec/requests/tasks_spec.rb
+++ b/spec/requests/tasks_spec.rb
@@ -79,8 +79,12 @@ RSpec.describe 'the tasks list' do
 
     it 'lists a task with an incomplete correction' do
       correcting_task_id = 'b847e0f7-027e-4b95-afa2-3490b8d05a1d'
+      correcting_submission_id = '43dfbd10-1c17-4f3c-8665-be8c27762923'
       assert_select "#task-#{correcting_task_id}" do
         assert_select '.govuk-tag__notice', text: 'Correction'
+        assert_select 'a[href=?]',
+                      task_submission_path(task_id: correcting_task_id, id: correcting_submission_id),
+                      text: 'View errors'
       end
     end
   end

--- a/spec/requests/tasks_spec.rb
+++ b/spec/requests/tasks_spec.rb
@@ -76,6 +76,13 @@ RSpec.describe 'the tasks list' do
                       text: 'Download template'
       end
     end
+
+    it 'lists a task with an incomplete correction' do
+      correcting_task_id = 'b847e0f7-027e-4b95-afa2-3490b8d05a1d'
+      assert_select "#task-#{correcting_task_id}" do
+        assert_select '.govuk-tag__notice', text: 'Correction'
+      end
+    end
   end
 
   context 'when signed-in as a user with no tasks' do

--- a/spec/support/api_helpers.rb
+++ b/spec/support/api_helpers.rb
@@ -153,7 +153,7 @@ module ApiHelpers
 
   def mock_incomplete_tasks_endpoint!
     stub_request(:get, api_url('tasks'))
-      .with(query: hash_including(filter: hash_including('status' => ['unstarted', 'in_progress'])))
+      .with(query: hash_including(filter: hash_including('status' => ['unstarted', 'in_progress', 'correcting'])))
       .to_return(
         headers: json_headers,
         body: json_fixture_file('incomplete_tasks_with_framework_and_active_submission.json')

--- a/spec/support/api_helpers.rb
+++ b/spec/support/api_helpers.rb
@@ -7,6 +7,10 @@ module ApiHelpers
     '2d98639e-5260-411f-a5ee-61847a2e067c'
   end
 
+  def mock_correcting_task_id
+    'b847e0f7-027e-4b95-afa2-3490b8d05a1d'
+  end
+
   def mock_submission_id
     '9a5ef62c-0781-4f80-8850-5793652b6b40'
   end
@@ -134,6 +138,19 @@ module ApiHelpers
       .to_return(headers: json_headers, body: json_fixture_file('task_with_framework.json'))
   end
 
+  def mock_correcting_task_with_framework_endpoint!
+    stub_request(:get, api_url("tasks/#{mock_correcting_task_id}?include=framework"))
+      .to_return(headers: json_headers, body: json_fixture_file('correcting_task_with_framework.json'))
+  end
+
+  def mock_correcting_task_with_framework_and_active_submission_endpoint!
+    stub_request(:get, api_url("tasks/#{mock_correcting_task_id}?include=framework,active_submission.files"))
+      .to_return(
+        headers: json_headers,
+        body: json_fixture_file('correcting_task_with_framework_and_active_submission.json')
+      )
+  end
+
   def mock_task_with_unsafe_short_name_framework_endpoint!
     json = JSON.parse(File.read(json_fixture_file('task_with_framework.json')))
     json['included'][0]['attributes']['short_name'] = 'CBOARD/5'
@@ -178,6 +195,20 @@ module ApiHelpers
   def mock_completed_task_endpoint!
     stub_request(:get, api_url("tasks/#{mock_task_id}?include=framework,active_submission.files"))
       .to_return(headers: json_headers, body: json_fixture_file('completed_task.json'))
+  end
+
+  def mock_task_endpoint!
+    stub_request(:get, api_url("tasks/#{mock_task_id}"))
+      .to_return(headers: json_headers, body: json_fixture_file('completed_task.json'))
+  end
+
+  def mock_correcting_task_endpoint!
+    stub_request(:get, api_url("tasks/#{mock_correcting_task_id}"))
+      .to_return(headers: json_headers, body: json_fixture_file('correcting_task.json'))
+  end
+
+  def mock_correction_cancellation_endpoint!
+    stub_request(:patch, api_url("tasks/#{mock_correcting_task_id}/cancel_correction"))
   end
 
   def mock_completed_task_with_no_business_endpoint!

--- a/spec/support/api_helpers.rb
+++ b/spec/support/api_helpers.rb
@@ -223,13 +223,13 @@ module ApiHelpers
       .to_return(headers: json_headers, body: submission_file_blob.to_json)
   end
 
-  def mock_update_task_endpoint!
+  def mock_update_task_endpoint!(status: 'in_progress')
     task_params = {
       data: {
         id: mock_task_id,
         type: 'tasks',
         attributes: {
-          status: 'in_progress'
+          status: status
         }
       }
     }


### PR DESCRIPTION
User can view the tasks where they have an incomplete correction submission on the homepage.

Tasks are marked as `correcting` when uploading a correction return.

User can cancel the correction. The correction files are deleted.

Note: this PR depends on https://github.com/dxw/DataSubmissionServiceAPI/pull/328 being merged and deployed.