### PR TITLE
Allow users to replace return in errors with no business

### DIFF
--- a/app/views/submissions/new.html.haml
+++ b/app/views/submissions/new.html.haml
@@ -38,3 +38,6 @@
         %input.govuk-input#purchase_order_number{ :type => 'text', :name => "purchase_order_number"}
       .govuk-form-group
         = submit_tag 'Upload and check file', data: { 'prevent-double-click': true }, class: 'govuk-button'
+    %p
+      Have no business to report?
+      = link_to 'Report no business', new_task_no_business_path(task_id: @task.id), {'aria-label' => "Report no business for #{@task.supplier_name} on #{@task.framework.short_name}"}


### PR DESCRIPTION
Once a user has started a business submission, they had no way of restarting the task and submitting no business instead. This led to support requests to reset tasks for users that wanted to do this.

This is resolved by simply putting this link into the new submission page, which is accessible from both the validation failed and in review states of an existsing submission.