### PR TITLE
Configure Service Connection Environment variables

### DIFF
--- a/config/initializers/load_cloud_factory_service_variables.rb
+++ b/config/initializers/load_cloud_factory_service_variables.rb
@@ -1,0 +1,1 @@
+VcapParser.load_service_environment_variables!

--- a/lib/vcap_parser.rb
+++ b/lib/vcap_parser.rb
@@ -1,0 +1,11 @@
+class VcapParser
+  def self.load_service_environment_variables!
+    return if ENV['VCAP_SERVICES'].blank?
+
+    JSON.parse(ENV['VCAP_SERVICES']).fetch('user-provided').each do |service|
+      service['credentials'].each_pair do |key, value|
+        ENV[key] = value
+      end
+    end
+  end
+end

--- a/spec/lib/vcap_parser_spec.rb
+++ b/spec/lib/vcap_parser_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+RSpec.describe VcapParser do
+  describe '.load_service_environment_variables!' do
+    it 'loads service level environment variables to the ENV' do
+      vcap_json = '
+        {
+           "user-provided": [
+            {
+             "credentials": {
+              "ENV1": "ENV1VALUE",
+              "ENV2": "ENV2VALUE"
+             }
+            }
+           ]
+         }
+      '
+      ClimateControl.modify VCAP_SERVICES: vcap_json do
+        VcapParser.load_service_environment_variables!
+        expect(ENV['ENV2']).to eq('ENV2VALUE')
+      end
+    end
+
+    it 'does not error if VCAP_SERVICES is not set' do
+      ClimateControl.modify VCAP_SERVICES: nil do
+        expect { VcapParser.load_service_environment_variables! }.to_not raise_error
+      end
+    end
+  end
+end


### PR DESCRIPTION
As part of moving to GPAS, we need to be able to load environment variables from VCAP_SERVICES as specified in https://docs.cloudfoundry.org/buildpacks/ruby/ruby-service-bindings.html

I tried using the cf-app-utils gem, but it's out of date, and was more trouble than just parsing the JSON manually.