### PR TITLE
Load S3 bucket config to ENV from VCAP

### DIFF
--- a/lib/vcap_parser.rb
+++ b/lib/vcap_parser.rb
@@ -2,10 +2,25 @@ class VcapParser
   def self.load_service_environment_variables!
     return if ENV['VCAP_SERVICES'].blank?
 
-    JSON.parse(ENV['VCAP_SERVICES']).fetch('user-provided').each do |service|
+    vcap_json = JSON.parse(ENV['VCAP_SERVICES'])
+    vcap_json.fetch('user-provided', []).each do |service|
       service['credentials'].each_pair do |key, value|
         ENV[key] = value
       end
     end
+
+    load_ingest_bucket_config(
+      vcap_json.fetch('aws-s3-bucket', [])
+               .find { |aws_config| aws_config.fetch('name').match?(/^ingest-bucket-/) }
+    )
+  end
+
+  def self.load_ingest_bucket_config(ingest_bucket_config)
+    return unless ingest_bucket_config
+
+    ENV['AWS_ACCESS_KEY_ID'] = ingest_bucket_config.fetch('credentials').fetch('aws_access_key_id')
+    ENV['AWS_SECRET_ACCESS_KEY'] = ingest_bucket_config.fetch('credentials').fetch('aws_secret_access_key')
+    ENV['AWS_S3_REGION'] = ENV['AWS_REGION'] = ingest_bucket_config.fetch('credentials').fetch('aws_region')
+    ENV['AWS_S3_BUCKET'] = ingest_bucket_config.fetch('credentials').fetch('bucket_name')
   end
 end

--- a/spec/lib/vcap_parser_spec.rb
+++ b/spec/lib/vcap_parser_spec.rb
@@ -21,6 +21,41 @@ RSpec.describe VcapParser do
       end
     end
 
+    it 'loads s3 bucket names to the ENV' do
+      vcap_json = '
+        {
+          "aws-s3-bucket": [
+            {
+              "credentials": {
+                "aws_access_key_id": "WRONG",
+                "aws_region": "WRONG",
+                "aws_secret_access_key": "WRONG",
+                "bucket_name": "WRONG"
+              },
+              "name": "another-bucket-production-spacename"
+            },
+            {
+              "credentials": {
+                "aws_access_key_id": "INGESTACCESSKEY",
+                "aws_region": "INGESTREGION",
+                "aws_secret_access_key": "INGESTACCESSKEYSECRET",
+                "bucket_name": "INGESTBUCKETNAME"
+              },
+              "name": "ingest-bucket-production-spacename"
+            }
+          ]
+        }
+      '
+      ClimateControl.modify VCAP_SERVICES: vcap_json do
+        VcapParser.load_service_environment_variables!
+        expect(ENV['AWS_ACCESS_KEY_ID']).to eq('INGESTACCESSKEY')
+        expect(ENV['AWS_SECRET_ACCESS_KEY']).to eq('INGESTACCESSKEYSECRET')
+        expect(ENV['AWS_S3_REGION']).to eq('INGESTREGION')
+        expect(ENV['AWS_REGION']).to eq('INGESTREGION')
+        expect(ENV['AWS_S3_BUCKET']).to eq('INGESTBUCKETNAME')
+      end
+    end
+
     it 'does not error if VCAP_SERVICES is not set' do
       ClimateControl.modify VCAP_SERVICES: nil do
         expect { VcapParser.load_service_environment_variables! }.to_not raise_error


### PR DESCRIPTION
In GPAAS, the S3 bucket configurations are given to us in the VCAP_SERVICES JSON.

This commit looks for an S3 bucket with a GPAAS name beginning with `ingest-bucket, and load that bucket's credentials to the ENV.