### PR TITLE
Add non secret environment variables to the manifest template

### DIFF
--- a/CF/manifest-template.yml
+++ b/CF/manifest-template.yml
@@ -12,5 +12,10 @@ applications:
       - DSSAPI
       - APP_SECRETBASE
       - GOOGLE_IDS
+    env:
+      RAILS_ENV: production
+      RACK_ENV: production
+      RAILS_SERVE_STATIC_FILES: enabled
+      CORRECTION_RETURNS_ENABLED: true
 
 


### PR DESCRIPTION
These environment variables are the same in both environments and are
not secrets so add them to manifest template.