### PR TITLE
(1043) Add additional page for a submission in the 'ingest_failed' state

### DIFF
--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -71,6 +71,7 @@ class SubmissionsController < ApplicationController
     when 'pending', 'processing' then :processing
     when 'in_review' then :in_review
     when 'validation_failed' then :validation_failed
+    when 'ingest_failed' then :ingest_failed
     when 'completed' then :completed
     end
   end

--- a/app/models/api/task.rb
+++ b/app/models/api/task.rb
@@ -12,7 +12,7 @@ module API
     end
 
     def errors?
-      (active_submission.try(:status) == 'validation_failed') || false
+      %w[validation_failed ingest_failed].include?(active_submission&.status) || false
     end
 
     def late?

--- a/app/views/submissions/ingest_failed.html.haml
+++ b/app/views/submissions/ingest_failed.html.haml
@@ -1,0 +1,32 @@
+.govuk-grid-row
+  .govuk-grid-column-full
+    = render 'shared/task_signpost', task: @task
+
+.govuk-grid-row
+  .govuk-grid-column-full
+    %h1.govuk-heading-xl
+      We were unable to process your file
+
+.govuk-grid-row
+  .govuk-grid-column-two-thirds
+    .govuk-error-summary{ :role=>"alert", :aria-labelledby=>"error-summary-heading", :tabindex=>"-1"}
+
+      %p
+        Please upload a file that is:
+
+      %ul.govuk-list.govuk-list--bullet
+        %li
+          in Excel format (.xls or .xlsx)
+        %li
+          based on the
+          = link_to "Excel template", task_template_path(@task), {'aria-label' => "Download template for #{@task.framework.short_name} #{@task.framework.name}"}
+          for
+          = @task.framework.short_name
+
+    = link_to 'Upload file', new_task_submission_path(@task.id), class: 'govuk-button'
+
+    %p
+      If your file is in the correct format but it is not being accepted please contact
+      = mail_to support_email_address
+      for help.
+

--- a/app/views/tasks/_submission_buttons.html.haml
+++ b/app/views/tasks/_submission_buttons.html.haml
@@ -1,7 +1,7 @@
 - case submission.status
 - when 'pending', 'processing'
     = link_to 'View progress', task_submission_path(task_id: task.id, id: submission.id), {class: 'govuk-button', 'aria-label' => "View progress of this task"}
-- when 'validation_failed'
+- when 'validation_failed', 'ingest_failed'
     = link_to 'View errors', task_submission_path(task_id: task.id, id: submission.id), {class: 'govuk-button', 'aria-label' => "View the errors for this task"}
     = link_to 'Upload amended file', new_task_submission_path(task_id: task.id), {class: 'govuk-button', 'aria-label' => "Upload an amended file for this task"}
 - when 'in_review'

--- a/spec/fixtures/mocks/task_with_submission_that_failed_ingest.json
+++ b/spec/fixtures/mocks/task_with_submission_that_failed_ingest.json
@@ -1,0 +1,37 @@
+{
+  "data": {
+    "id": "2d98639e-5260-411f-a5ee-61847a2e067c",
+    "type": "tasks",
+    "attributes": {
+      "description": "test task",
+      "due_on": "2030-01-01",
+      "period_month": 7,
+      "period_year": 2018,
+      "status": "unstarted",
+      "framework_id": "f87717d4-874a-43d9-b99f-c8cf2897b526",
+      "supplier_id": "cd40ead8-67b5-4918-abf0-ab8937cd04ff",
+      "supplier_name": "Bobs Cheese Shop"
+    },
+    "relationships": {
+      "active_submission": {
+        "data": {
+          "type": "submissions",
+          "id": "63996088-5c20-4e65-b722-287fafeedc97"
+        }
+      }
+    }
+  },
+  "included": [
+    {
+      "id": "63996088-5c20-4e65-b722-287fafeedc97",
+      "type": "submissions",
+      "attributes": {
+        "framework_id": "f87717d4-874a-43d9-b99f-c8cf2897b526",
+        "supplier_id": "cd40ead8-67b5-4918-abf0-ab8937cd04ff",
+        "task_id": "2d98639e-5260-411f-a5ee-61847a2e067c",
+        "status": "ingest_failed"
+      }
+    }
+  ]
+}
+

--- a/spec/models/api/task_spec.rb
+++ b/spec/models/api/task_spec.rb
@@ -11,8 +11,15 @@ RSpec.describe API::Task do
   end
 
   describe '#errors?' do
-    it 'returns true if the latest submission is errored' do
+    it 'returns true if the latest submission has validation errors' do
       mock_task_with_invalid_submission_endpoint!
+      task_with_invalid_submission = API::Task.includes(:active_submission).find(mock_task_id).first
+
+      expect(task_with_invalid_submission.errors?).to be_truthy
+    end
+
+    it 'returns true if the latest submission failed to be ingested' do
+      mock_task_with_submission_that_failed_ingest_endpoint!
       task_with_invalid_submission = API::Task.includes(:active_submission).find(mock_task_id).first
 
       expect(task_with_invalid_submission.errors?).to be_truthy

--- a/spec/support/api_helpers.rb
+++ b/spec/support/api_helpers.rb
@@ -174,6 +174,11 @@ module ApiHelpers
       .to_return(headers: json_headers, body: json_fixture_file('task_with_invalid_submission.json'))
   end
 
+  def mock_task_with_submission_that_failed_ingest_endpoint!
+    stub_request(:get, api_url("tasks/#{mock_task_id}?include=active_submission"))
+      .to_return(headers: json_headers, body: json_fixture_file('task_with_submission_that_failed_ingest.json'))
+  end
+
   def mock_task_with_valid_submission_endpoint!
     stub_request(:get, api_url("tasks/#{mock_task_id}?include=active_submission"))
       .to_return(headers: json_headers, body: json_fixture_file('task_with_valid_submission.json'))


### PR DESCRIPTION
This will be displayed when ingest fails to process a file, which will allow the user to continue without intervention from support.

<img width="1059" alt="Screenshot 2019-05-13 at 11 23 01" src="https://user-images.githubusercontent.com/3166/57614689-bc27f400-7571-11e9-8306-1361c124c4db.png">

NB: This won't actually be visible to users until changes are made to the API, but wanted to have this in place ready.