### PR TITLE
(1050) Fetch URN list from API and allow user to download it

### DIFF
--- a/app/controllers/urns_controller.rb
+++ b/app/controllers/urns_controller.rb
@@ -1,3 +1,23 @@
 class UrnsController < ApplicationController
-  def index; end
+  def show
+    @urn_list = API::UrnList.first
+  end
+
+  def download
+    urn_list = API::UrnList.first
+
+    if urn_list.present?
+      urn_list_file = s3_client.get_object(bucket: ENV['AWS_S3_BUCKET'], key: urn_list.file_key)
+      send_data urn_list_file.body.read, filename: urn_list.filename
+    else
+      urn_list_file = Rails.root.join('public', 'urn', 'CCS-URN-List-(27-March-2019).xls')
+      send_file urn_list_file, filename: 'CCS-URN-List-(27-March-2019).xls'
+    end
+  end
+
+  private
+
+  def s3_client
+    @s3_client ||= Aws::S3::Client.new(region: ENV['AWS_S3_REGION'], stub_responses: Rails.env.test?)
+  end
 end

--- a/app/models/api/urn_list.rb
+++ b/app/models/api/urn_list.rb
@@ -1,0 +1,3 @@
+module API
+  class UrnList < Base; end
+end

--- a/app/views/urns/show.html.haml
+++ b/app/views/urns/show.html.haml
@@ -12,9 +12,14 @@
       URN, you can look it up in this Excel file:
 
     %p
-      = link_to 'Download CCS URN List (27 March 2019).xls',
-        '/urn/CCS-URN-List-(27-March-2019).xls'
-      (12MB)
+      - if @urn_list.present?
+        = link_to "Download #{@urn_list.filename}", download_urns_path
+        = surround '(', ')' do
+          = number_to_human_size(@urn_list.byte_size)
+      - else
+        = link_to 'Download CCS URN List (27 March 2019).xls',
+          '/urn/CCS-URN-List-(27-March-2019).xls'
+        (12MB)
 
     %p
       Open this file in Microsoft Excel and use the 'find' tool within Excel to

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,11 +25,16 @@ Rails.application.routes.draw do
     resource :no_business, only: %i[new create]
   end
 
+  resource :urns, only: :show do
+    member do
+      get :download
+    end
+  end
+
   get '/auth/:provider/callback', to: 'sessions#create'
   get '/auth/failure', to: 'errors#auth_failure'
   get '/sign_out', to: 'sessions#destroy', as: :sign_out
   get '/style_guide', to: 'styleguide#index'
-  get '/urns', to: 'urns#index'
   get '/support', to: 'support#index'
   get '/support/frameworks', to: 'support#frameworks'
 end

--- a/spec/fixtures/mocks/urn_lists.json
+++ b/spec/fixtures/mocks/urn_lists.json
@@ -1,0 +1,14 @@
+{
+  "data": {
+    "id": "e7069d20-2fcd-4b72-b891-55da8db5461e",
+    "type": "urn_list",
+    "attributes": {
+      "file_key": "17s6KEix4RRSiQQnurt7Br4q",
+      "filename": "CCS URN List (20 May 2019).xls",
+      "byte_size": 4133308
+    }
+  },
+  "jsonapi": {
+    "version": "1.0"
+  }
+}

--- a/spec/fixtures/mocks/urn_lists_empty.json
+++ b/spec/fixtures/mocks/urn_lists_empty.json
@@ -1,0 +1,6 @@
+{
+  "data": null,
+  "jsonapi": {
+    "version": "1.0"
+  }
+}

--- a/spec/requests/urns_spec.rb
+++ b/spec/requests/urns_spec.rb
@@ -1,13 +1,46 @@
 require 'rails_helper'
 
 RSpec.describe 'the urns page' do
+  around(:each) do |example|
+    ClimateControl.modify AWS_S3_BUCKET: 'bucket-name', AWS_S3_REGION: 'zz-north-1' do
+      example.run
+    end
+  end
+
   it 'has a link to download the URNs file' do
     stub_signed_in_user
+    mock_urn_lists_endpoint!
 
     get urns_path
 
     expect(response).to be_successful
-    assert_select 'a[href=?]', '/urn/CCS-URN-List-(27-March-2019).xls',
-                  text: 'Download CCS URN List (27 March 2019).xls'
+    assert_select 'a[href=?]', '/urns/download',
+                  text: 'Download CCS URN List (20 May 2019).xls'
+  end
+
+  context 'when file key exists' do
+    it 'returns the URN list' do
+      stub_signed_in_user
+      mock_urn_lists_endpoint!
+
+      get download_urns_path
+
+      expect(response).to be_successful
+      expected_disposition = 'attachment; filename="CCS URN List (20 May 2019).xls"'
+      expect(response.headers['Content-Disposition']).to eq(expected_disposition)
+    end
+  end
+
+  context 'when there are no acceptable URN lists' do
+    it 'returns an older URN list from the filesystem' do
+      stub_signed_in_user
+      mock_empty_urn_lists_endpoint!
+
+      get download_urns_path
+
+      expect(response).to be_successful
+      expected_disposition = 'attachment; filename="CCS-URN-List-(27-March-2019).xls"'
+      expect(response.headers['Content-Disposition']).to eq(expected_disposition)
+    end
   end
 end

--- a/spec/support/api_helpers.rb
+++ b/spec/support/api_helpers.rb
@@ -292,6 +292,22 @@ module ApiHelpers
       )
   end
 
+  def mock_urn_lists_endpoint!
+    stub_request(:get, api_url('urn_lists?page%5Bpage%5D=1&page%5Bper_page%5D=1'))
+      .to_return(
+        headers: json_headers,
+        body: json_fixture_file('urn_lists.json')
+      )
+  end
+
+  def mock_empty_urn_lists_endpoint!
+    stub_request(:get, api_url('urn_lists?page%5Bpage%5D=1&page%5Bper_page%5D=1'))
+      .to_return(
+        headers: json_headers,
+        body: json_fixture_file('urn_lists_empty.json')
+      )
+  end
+
   private
 
   def json_headers


### PR DESCRIPTION
Fetch the latest URN list using the new `GET /v1/urn_lists` endpoint and display the details to the user. If a valid URN list is not available, we fallback to the existing one. 

**Depends on: https://github.com/dxw/DataSubmissionServiceAPI/pull/439**