### PR TITLE
Use v3 cf-cli commands to make deploys better

### DIFF
--- a/CF/deploy-app.sh
+++ b/CF/deploy-app.sh
@@ -120,8 +120,9 @@ sed "s/CF_SPACE/$CF_SPACE/g" manifest-template.yml | sed "s/MEMORY_LIMIT/$MEMORY
 
 # push
 cd .. || exit
-if cf app ccs-rmi-app-"$CF_SPACE"; then
-  cf blue-green-deploy ccs-rmi-app-"$CF_SPACE" -f CF/"$CF_SPACE".manifest.yml
-else
-  cf push -f CF/"$CF_SPACE".manifest.yml
-fi
+
+# create an app idempotently with the v3 cli
+cf v3-create-app ccs-rmi-app-"$CF_SPACE"
+cf v3-apply-manifest -f CF/"$CF_SPACE".manifest.yml
+# do a zero down time deployment with the v3 cli
+cf cf v3-zdt-push ccs-rmi-app-"$CF_SPACE"


### PR DESCRIPTION
The v3 cf-cli commands deal with zero down time deploys better.
In particular our network policy to talk to the internal API was not
dealt with correctly by the blue-green plugin.