### PR TITLE
(1093) Don't forget if submission is a replacement on ingest failed

### DIFF
--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -78,14 +78,14 @@ class SubmissionsController < ApplicationController
 
   def handle_file_extension_validation
     redirect_to(
-      new_task_submission_path(task_id: params[:task_id]),
+      new_task_submission_path(task_id: params[:task_id], correction: params[:correction]),
       flash: { alert: 'Uploaded file must be in Microsoft Excel format (either .xlsx or .xls)' }
     )
   end
 
   def handle_file_presence_validation
     redirect_to(
-      new_task_submission_path(task_id: params[:task_id]),
+      new_task_submission_path(task_id: params[:task_id], correction: params[:correction]),
       flash: { alert: 'Please select a file' }
     )
   end

--- a/app/views/submissions/ingest_failed.html.haml
+++ b/app/views/submissions/ingest_failed.html.haml
@@ -23,10 +23,9 @@
           for
           = @task.framework.short_name
 
-    = link_to 'Upload file', new_task_submission_path(@task.id), class: 'govuk-button'
+    = link_to 'Upload file', new_task_submission_path(@task.id, correction: params[:correction]), class: 'govuk-button'
 
     %p
       If your file is in the correct format but it is not being accepted please contact
       = mail_to support_email_address
       for help.
-

--- a/app/views/tasks/_submission_buttons.html.haml
+++ b/app/views/tasks/_submission_buttons.html.haml
@@ -3,6 +3,6 @@
     = link_to 'View progress', task_submission_path(task_id: task.id, id: submission.id), {class: 'govuk-button', 'aria-label' => "View progress of this task"}
 - when 'validation_failed', 'ingest_failed'
     = link_to 'View errors', task_submission_path(task_id: task.id, id: submission.id), {class: 'govuk-button', 'aria-label' => "View the errors for this task"}
-    = link_to 'Upload amended file', new_task_submission_path(task_id: task.id), {class: 'govuk-button', 'aria-label' => "Upload an amended file for this task"}
+    = link_to 'Upload amended file', new_task_submission_path(task_id: task.id, correction: task.correcting?), {class: 'govuk-button', 'aria-label' => "Upload an amended file for this task"}
 - when 'in_review'
     = link_to 'Submit management information', task_submission_path(task_id: task.id, id: submission.id), {class: 'govuk-button', 'aria-label' => "Submit management information for this task"}


### PR DESCRIPTION
In the new ingest failed page, we didn't pass through the correction param flag on the retry button, which led to users trying to submit a new submission against a completed task, resulting in confusing error messages.