### PR TITLE
Address CVE-2015-9284

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,6 +36,7 @@ gem 'bootsnap', '>= 1.1.0', require: false
 # Authentication
 gem 'omniauth'
 gem 'omniauth-auth0', '~> 2.0.0'
+gem 'omniauth-rails_csrf_protection'
 
 # API requests
 gem 'httparty'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -190,6 +190,9 @@ GEM
     omniauth-oauth2 (1.5.0)
       oauth2 (~> 1.1)
       omniauth (~> 1.2)
+    omniauth-rails_csrf_protection (0.1.2)
+      actionpack (>= 4.2)
+      omniauth (>= 1.3.1)
     parallel (1.12.1)
     parser (2.5.1.0)
       ast (~> 2.4.0)
@@ -358,6 +361,7 @@ DEPENDENCIES
   mini_racer
   omniauth
   omniauth-auth0 (~> 2.0.0)
+  omniauth-rails_csrf_protection
   pg (>= 0.18, < 2.0)
   poltergeist
   pry-rails

--- a/app/views/home/guest_homepage.html.haml
+++ b/app/views/home/guest_homepage.html.haml
@@ -21,7 +21,7 @@
       If you didn’t do any business, you still need to sign in and let us know.
 
     %p{class: 'govuk-!-margin-top-9'}
-      = link_to 'Sign in', '/auth/auth0', class: 'govuk-button govuk-button--start', id: 'sign-in', 'aria-label' => "Sign in to the service"
+      = button_to 'Sign in', '/auth/auth0', class: 'govuk-button govuk-button--start', id: 'sign-in', 'aria-label' => "Sign in to the service"
 
     %h2.govuk-heading-m
       If you’re having trouble signing in

--- a/spec/features/task_management_spec.rb
+++ b/spec/features/task_management_spec.rb
@@ -10,7 +10,7 @@ RSpec.feature 'task management' do
     mock_user_endpoint!
 
     visit '/'
-    click_link 'sign-in'
+    click_button 'sign-in'
 
     visit '/tasks'
 
@@ -52,7 +52,7 @@ RSpec.feature 'task management' do
     mock_submission_errored_endpoint!
 
     visit '/'
-    click_link 'sign-in'
+    click_button 'sign-in'
 
     visit task_submission_path(task_id: mock_task_id, id: mock_submission_id)
 
@@ -72,7 +72,7 @@ RSpec.feature 'task management' do
     mock_user_with_multiple_suppliers_endpoint!
 
     visit '/'
-    click_link 'sign-in'
+    click_button 'sign-in'
 
     visit '/tasks'
 

--- a/spec/features/user_can_cancel_correction_spec.rb
+++ b/spec/features/user_can_cancel_correction_spec.rb
@@ -14,7 +14,7 @@ RSpec.feature 'Cancelling a correction submission' do
       mock_user_endpoint!
       mock_sso_with(email: 'email@example.com')
       mock_incomplete_tasks_endpoint!
-      click_link 'sign-in'
+      click_button 'sign-in'
 
       mock_correcting_task_with_framework_endpoint!
       click_link 'Cancel correction'

--- a/spec/features/user_can_correct_submission_with_mi_return_spec.rb
+++ b/spec/features/user_can_correct_submission_with_mi_return_spec.rb
@@ -15,7 +15,7 @@ RSpec.feature 'Correcting a submission by reporting MI return' do
       mock_sso_with(email: 'email@example.com')
       mock_task_with_framework_endpoint!
       mock_incomplete_tasks_endpoint!
-      click_link 'sign-in'
+      click_button 'sign-in'
 
       mock_complete_tasks_endpoint!
       click_link 'History'

--- a/spec/features/user_can_correct_submission_with_no_business_spec.rb
+++ b/spec/features/user_can_correct_submission_with_no_business_spec.rb
@@ -26,7 +26,7 @@ RSpec.feature 'Correcting a submission by reporting no business' do
         mock_user_endpoint!
 
         visit '/'
-        click_link 'sign-in'
+        click_button 'sign-in'
 
         click_link 'History'
         click_link 'View'
@@ -56,7 +56,7 @@ RSpec.feature 'Correcting a submission by reporting no business' do
         mock_user_with_multiple_suppliers_endpoint!
 
         visit '/'
-        click_link 'sign-in'
+        click_button 'sign-in'
 
         click_link 'History'
         click_link 'View'
@@ -91,7 +91,7 @@ RSpec.feature 'Correcting a submission by reporting no business' do
         mock_user_endpoint!
 
         visit '/'
-        click_link 'sign-in'
+        click_button 'sign-in'
 
         click_link 'History'
         click_link 'View'
@@ -117,7 +117,7 @@ RSpec.feature 'Correcting a submission by reporting no business' do
       mock_user_endpoint!
 
       visit '/'
-      click_link 'sign-in'
+      click_button 'sign-in'
 
       click_link 'History'
       click_link 'View'

--- a/spec/features/user_can_submit_no_business_spec.rb
+++ b/spec/features/user_can_submit_no_business_spec.rb
@@ -15,7 +15,7 @@ RSpec.feature 'Submitting no business' do
     mock_user_endpoint!
 
     visit '/'
-    click_link 'sign-in'
+    click_button 'sign-in'
 
     visit '/tasks'
 
@@ -40,7 +40,7 @@ RSpec.feature 'Submitting no business' do
     mock_user_with_multiple_suppliers_endpoint!
 
     visit '/'
-    click_link 'sign-in'
+    click_button 'sign-in'
 
     visit '/tasks'
 

--- a/spec/features/users_can_download_their_submissions_spec.rb
+++ b/spec/features/users_can_download_their_submissions_spec.rb
@@ -9,7 +9,7 @@ RSpec.feature 'downloading a submission' do
     mock_completed_task_endpoint!
 
     visit '/'
-    click_link 'sign-in'
+    click_button 'sign-in'
 
     visit "/tasks/#{mock_task_id}"
 

--- a/spec/features/users_can_upload_completed_spreadsheet_spec.rb
+++ b/spec/features/users_can_upload_completed_spreadsheet_spec.rb
@@ -12,7 +12,7 @@ RSpec.feature 'User uploads completed spreadsheet' do
       mock_sso_with(email: 'email@example.com')
 
       visit '/'
-      click_link 'sign-in'
+      click_button 'sign-in'
 
       visit '/tasks'
       click_on 'Report management information'
@@ -31,7 +31,7 @@ RSpec.feature 'User uploads completed spreadsheet' do
       mock_user_endpoint!
 
       visit '/'
-      click_link 'sign-in'
+      click_button 'sign-in'
 
       visit '/tasks'
       click_on 'Report management information'
@@ -53,7 +53,7 @@ RSpec.feature 'User uploads completed spreadsheet' do
       mock_user_with_multiple_suppliers_endpoint!
 
       visit '/'
-      click_link 'sign-in'
+      click_button 'sign-in'
 
       visit '/tasks'
 
@@ -78,7 +78,7 @@ RSpec.feature 'User uploads completed spreadsheet' do
       mock_user_endpoint!
 
       visit '/'
-      click_link 'sign-in'
+      click_button 'sign-in'
 
       visit '/tasks'
       click_on 'Report management information'
@@ -96,7 +96,7 @@ RSpec.feature 'User uploads completed spreadsheet' do
       mock_user_endpoint!
 
       visit '/'
-      click_link 'sign-in'
+      click_button 'sign-in'
 
       visit '/tasks'
       click_on 'Report management information'
@@ -117,7 +117,7 @@ RSpec.feature 'User uploads completed spreadsheet' do
       mock_user_with_multiple_suppliers_endpoint!
 
       visit '/'
-      click_link 'sign-in'
+      click_button 'sign-in'
 
       visit '/tasks/2d98639e-5260-411f-a5ee-61847a2e067c/submissions/9a5ef62c-0781-4f80-8850-5793652b6b40'
 
@@ -136,7 +136,7 @@ RSpec.feature 'User uploads completed spreadsheet' do
       mock_complete_submission_endpoint!
 
       visit '/'
-      click_link 'sign-in'
+      click_button 'sign-in'
 
       visit '/tasks/2d98639e-5260-411f-a5ee-61847a2e067c/submissions/9a5ef62c-0781-4f80-8850-5793652b6b40'
 


### PR DESCRIPTION
Github recently raised a security notification for all projects relying on omniauth, but omniauth don't have a fix for this yet. (see omniauth/omniauth#809)

I'm therefore leaning towards what @tekin has done with DFE-Digital/dfe-teachers-payment-service#104 and locking down the get action anyway, using the omniauth-rails_csrf_protection gem.