### PR TITLE
Use AWS API for supplier downloading submission file

### DIFF
--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -22,13 +22,10 @@ class SubmissionsController < ApplicationController
   end
 
   def download
-    submission = API::Submission
-                 .includes(:files)
-                 .find(params[:id]).first
+    submission = API::Submission.find(params[:id]).first
 
-    file = submission.files.first
-
-    redirect_to file.temporary_download_url, status: :temporary_redirect
+    submission_file = s3_client.get_object(bucket: ENV['AWS_S3_BUCKET'], key: submission.file_key)
+    send_data submission_file.body.read, filename: submission.filename
   end
 
   private
@@ -99,5 +96,9 @@ class SubmissionsController < ApplicationController
     handle_file_presence_validation && return if params[:upload].nil?
 
     handle_file_extension_validation unless acceptable_file_extension?
+  end
+
+  def s3_client
+    @s3_client ||= Aws::S3::Client.new(region: ENV['AWS_S3_REGION'], stub_responses: Rails.env.test?)
   end
 end

--- a/spec/fixtures/mocks/submission_with_file.json
+++ b/spec/fixtures/mocks/submission_with_file.json
@@ -12,29 +12,9 @@
       "order_total_value": 42.42,
       "purchase_order_number": null,
       "status": "completed",
-      "report_no_business?": false
-    },
-    "relationships": {
-      "files": {
-        "data": [
-          {
-            "type": "submission_files",
-            "id": "8d0e4289-5fde-4faa-b78e-922846d8460a"
-          }
-        ]
-      }
+      "report_no_business?": false,
+      "file_key": "12345",
+      "filename": "file.xlsx"
     }
-  },
-  "included": [
-    {
-      "id": "8d0e4289-5fde-4faa-b78e-922846d8460a",
-      "type": "submission_files",
-      "attributes": {
-        "submission_id": "9a5ef62c-0781-4f80-8850-5793652b6b40",
-        "temporary_download_url": "http://s3.example.com/example.xls",
-        "filename": "example.xls",
-        "rows": 3
-      }
-    }
-  ]
+  }
 }

--- a/spec/requests/submissions_download_spec.rb
+++ b/spec/requests/submissions_download_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'downloading a submission' do
 
     get download_task_submission_path(mock_task_id, mock_submission_id)
 
-    expect(response.status).to eql 307
-    expect(response).to redirect_to('http://s3.example.com/example.xls')
+    expect(response.body).to eq('')
+    expect(response.header['Content-Type']).to eql('application/octet-stream')
   end
 end

--- a/spec/support/api_helpers.rb
+++ b/spec/support/api_helpers.rb
@@ -92,7 +92,7 @@ module ApiHelpers
   def mock_submission_with_file_endpoint!
     stub_request(
       :get,
-      api_url("submissions/#{mock_submission_id}?include=files")
+      api_url("submissions/#{mock_submission_id}")
     ).to_return(headers: json_headers, body: json_fixture_file('submission_with_file.json'))
   end
 


### PR DESCRIPTION
Because GPAAS doesn't allow us to use temporary_download_url, we need to use the AWS S3 library to retrieve the file to then send to the supplier.