### PR TITLE
Remove Sign In Link in header

### DIFF
--- a/app/views/shared/_header.html.haml
+++ b/app/views/shared/_header.html.haml
@@ -26,6 +26,3 @@
                 = link_to 'Support', support_path, {:class=>"govuk-header__link"}
               %li.govuk-header__navigation-item
                 = link_to "Sign out", '/sign_out', {:class=>"govuk-header__link"}
-            - else
-              %li.govuk-header__navigation-item
-                = link_to 'Sign in', '/auth/auth0', {:class=>"govuk-header__link"}

--- a/spec/features/users_can_sign_in_and_out_spec.rb
+++ b/spec/features/users_can_sign_in_and_out_spec.rb
@@ -34,6 +34,6 @@ RSpec.feature 'Signing in and out as a user' do
     visit '/'
     click_on 'Sign out'
 
-    expect(page).to have_content 'Sign in'
+    expect(page).to_not have_content 'Sign out'
   end
 end


### PR DESCRIPTION
Now that we forbid GET requests to omniauth sign in for security reasons, the header would either need to be a button, or not exist. After speaking to @mec, we've decided to remove it.