### PR TITLE
Fix occasional build failure

### DIFF
--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -99,6 +99,6 @@ class SubmissionsController < ApplicationController
   end
 
   def s3_client
-    @s3_client ||= Aws::S3::Client.new(region: ENV['AWS_S3_REGION'], stub_responses: Rails.env.test?)
+    @s3_client ||= Aws::S3::Client.new(region: ENV['AWS_S3_REGION'])
   end
 end

--- a/spec/requests/submissions_download_spec.rb
+++ b/spec/requests/submissions_download_spec.rb
@@ -1,14 +1,17 @@
 require 'rails_helper'
 
 RSpec.describe 'downloading a submission' do
-  it 'redirects the user to the S3 download link' do
+  let(:fake_s3_client) { spy('Aws::S3::Client') }
+  before do
     stub_signed_in_user
-
+    allow_any_instance_of(SubmissionsController).to receive(:s3_client).and_return(fake_s3_client)
     mock_submission_with_file_endpoint!
 
     get download_task_submission_path(mock_task_id, mock_submission_id)
+  end
 
-    expect(response.body).to eq('')
+  it 'downloads the submission file directly from S3 using the file_key in the API’s response' do
+    expect(fake_s3_client).to have_received(:get_object).with(a_hash_including(key: '12345'))
     expect(response.header['Content-Type']).to eql('application/octet-stream')
   end
 end


### PR DESCRIPTION
For some reason, on intermittent CI builds, AWS_S3_REGION is not set,
causing this error in the aws-partitions gem:

```
NoMethodError:
  undefined method `match' for nil:NilClass
```

Avoid using a real S3 client at all so we don't have to configure it by
supplying a spy instead, and check we talked to our fake S3 with the
`file_key` we mocked.

While here, change the title of the example, which referred to what it
used to do.