### PR TITLE
Add the correction param to view errors button

### DIFF
--- a/app/views/tasks/_submission_buttons.html.haml
+++ b/app/views/tasks/_submission_buttons.html.haml
@@ -2,7 +2,7 @@
 - when 'pending', 'processing'
     = link_to 'View progress', task_submission_path(task_id: task.id, id: submission.id), {class: 'govuk-button', 'aria-label' => "View progress of this task"}
 - when 'validation_failed', 'ingest_failed'
-    = link_to 'View errors', task_submission_path(task_id: task.id, id: submission.id), {class: 'govuk-button', 'aria-label' => "View the errors for this task"}
+    = link_to 'View errors', task_submission_path(task_id: task.id, id: submission.id, correction: task.correcting?), {class: 'govuk-button', 'aria-label' => "View the errors for this task"}
     = link_to 'Upload amended file', new_task_submission_path(task_id: task.id, correction: task.correcting?), {class: 'govuk-button', 'aria-label' => "Upload an amended file for this task"}
 - when 'in_review'
     = link_to 'Submit management information', task_submission_path(task_id: task.id, id: submission.id), {class: 'govuk-button', 'aria-label' => "Submit management information for this task"}

--- a/spec/requests/tasks_spec.rb
+++ b/spec/requests/tasks_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe 'the tasks list' do
       assert_select "#task-#{correcting_task_id}" do
         assert_select '.govuk-tag__notice', text: 'Correction'
         assert_select 'a[href=?]',
-                      task_submission_path(task_id: correcting_task_id, id: correcting_submission_id),
+                      task_submission_path(task_id: correcting_task_id, id: correcting_submission_id, correction: true),
                       text: 'View errors'
       end
     end


### PR DESCRIPTION
A user who is trying to correct their return from the 'view errors' page
would cause a 500 error because the 'correction' param was not set.