### PR TITLE
Use an app specific AUTH0 user service

### DIFF
--- a/CF/manifest-template.yml
+++ b/CF/manifest-template.yml
@@ -7,7 +7,7 @@ applications:
       - ccs-rmi-app-CF_SPACE
       - ingest-bucket-CF_SPACE
       - ccs-rmi-logging-CF_SPACE
-      - AUTH0
+      - APP_AUTH0
       - SKYLIGHT
       - ROLLBAR
       - DSSAPI


### PR DESCRIPTION
In production we have 2 different AUTH0 clients with different levels of
access.

Make the APP use the one with the access the APP needs.