### PR TITLE
(chore) Web can make requests to the API via Docker

### DIFF
--- a/docker-compose.env.sample
+++ b/docker-compose.env.sample
@@ -1,4 +1,5 @@
 DATABASE_URL=postgres://postgres@db:5432/DataSubmissionService_development?template=template0&pool=5&encoding=unicode
+API_ROOT=api:3000/
 AUTH0_DOMAIN=
 AUTH0_CLIENT_ID=
 AUTH0_CLIENT_SECRET=

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,13 +20,22 @@ services:
       - .:/srv/dss:cached
     command: bash -c "rm -f tmp/pids/server.pid && rails s"
     container_name: "data-submission-service_web"
-
+    networks:
+      private:
+      datasubmissionserviceapi_public:
   db:
     image: postgres
     volumes:
       - pg_data:/var/lib/postgresql/data/:cached
     restart: on-failure
     container_name: "data-submission-service_db"
-
+    networks:
+      private:
 volumes:
   pg_data: {}
+
+networks:
+  public:
+  private:
+  datasubmissionserviceapi_public:
+    external: true


### PR DESCRIPTION
* There was no way for this projects web conainter to make connections using `ENV['API_ROOT'] => localhost:3000` to communicate with the API project/containers that support it with data.
* We have made a change to the API to expose itself via a public Docker network, under the alias `api`. This will now allow us to make requests to api:3000 and Docker will be able to resolve that domain name to a dynamic IP.
* This does introduce an explicit dependency between this application and the API, it will not be able to start without the presence of a API network. This can be created to allow the app to boot independently following the Docker-compose error prompt. The alternative in the non-docker world would be for the app to boot without an API being started but for the first request to fail. These failures are currently not handled well and will bubble up in the form of type mismatch errors. I imagine that the number of times frontend will need to be running without the API is very small so on the whole I feel it is better to have this coupling as an explicit error that fails early is helpful.