### PR TITLE
Chore/deployment using docker containers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,35 +2,46 @@ language: ruby
 rvm:
 - 2.5.5
 services:
-  - postgresql
-addons:
-  postgresql: "10"
-apt:
-  packages:
-  - postgresql-10
-  - postgresql-client-10
-dist: xenial
-cache:
-  - bundler
+- docker
+cache: bundler
 env:
   matrix:
-    - API_ROOT='https://ccs.api/'
+  - API_ROOT='https://ccs.api/'
   global:
-    - CF_USER=systems-gpass@dxw.com
-    - CF_ORG=ccs-report-management-info
-    - secure: "aYw/Bw+oshNQK8GbApITzHP8sijvCt6WlZit2ZKtGTslGXftfkHD8C6jAfF2mHdFzLcffo46PV3vQHAKxp8GFE3qptyoLyQYOuw9FPORpfpUGaCrTiBfI+qA+pqNBLttI4muZWe+doJDX6zNEXKjjhwdjN8y8ZULxZG+xcVuH7mVnqHEEl9mb3QAYwglN9DrEeqf00pcx5EP846NOd9s4MKVGe/V3zhHUF/S7+yMS+CKuHKAcrq3r7yvOeGoZPF9okb7Sy0e3xOhIN0V6Wq6IZPLk/d8WwV8w0Gtdzu3V58i8Fr5DWLj5ok49XUhyctBH5EehhN8JNtYPNJB01+lMd4FO0CQv6E+mDyspvPyHBemol8oPTwZmkNlO9nHMmoe3bW38PapktNzvFw5QkONIUuUzh7dY7++0jia9VfbyYjgTjMCXNzN9pMzH6T6hmAVSPsb3OZRn72WogBTUlna9tHU69ieiatLlEK7NV6QitF2Z8IRhF9iW+kKYjkKEJuUo6rHwTmXhbQkdyDMTFSKpmA5V2mypqkT5jUcMN9AY6A8k+AwjlP8GIOURxaEVOiqVYS5HkneZb9Df0Js7p35mG9UkvXNbOdCylWt2/PA9xKmzCy3QeZf51cMd1rrUTRsG6RfMsao+/SN/jxO3sI0lZOaftvBrUYcQj9g5cS+2dY="
-before_script:
-  - bundle exec bin/rails db:migrate RAILS_ENV=test
-  - bundle exec rake AWS_ACCESS_KEY_ID=dummy AWS_SECRET_ACCESS_KEY=dummy AWS_S3_REGION=dummy AWS_S3_BUCKET=dummy SECRET_KEY_BASE=dummy DATABASE_URL=postgresql:does_not_exist --quiet assets:precompile
-before_deploy:
-  - echo "install cloudfoundry cli"
-  - wget -q -O - https://packages.cloudfoundry.org/debian/cli.cloudfoundry.org.key | sudo apt-key add -
-  - echo "deb https://packages.cloudfoundry.org/debian stable main" | sudo tee /etc/apt/sources.list.d/cloudfoundry-cli.list
-  - sudo apt-get update -qq
-  - sudo apt-get install cf-cli
-  - cf add-plugin-repo CF-Community https://plugins.cloudfoundry.org
-  - cf install-plugin blue-green-deploy -f -r CF-Community
+  - CF_USER=systems-gpass@dxw.com
+  - CF_ORG=ccs-report-management-info
+  - DOCKER_USERNAME=dxwempire
+  - secure: aYw/Bw+oshNQK8GbApITzHP8sijvCt6WlZit2ZKtGTslGXftfkHD8C6jAfF2mHdFzLcffo46PV3vQHAKxp8GFE3qptyoLyQYOuw9FPORpfpUGaCrTiBfI+qA+pqNBLttI4muZWe+doJDX6zNEXKjjhwdjN8y8ZULxZG+xcVuH7mVnqHEEl9mb3QAYwglN9DrEeqf00pcx5EP846NOd9s4MKVGe/V3zhHUF/S7+yMS+CKuHKAcrq3r7yvOeGoZPF9okb7Sy0e3xOhIN0V6Wq6IZPLk/d8WwV8w0Gtdzu3V58i8Fr5DWLj5ok49XUhyctBH5EehhN8JNtYPNJB01+lMd4FO0CQv6E+mDyspvPyHBemol8oPTwZmkNlO9nHMmoe3bW38PapktNzvFw5QkONIUuUzh7dY7++0jia9VfbyYjgTjMCXNzN9pMzH6T6hmAVSPsb3OZRn72WogBTUlna9tHU69ieiatLlEK7NV6QitF2Z8IRhF9iW+kKYjkKEJuUo6rHwTmXhbQkdyDMTFSKpmA5V2mypqkT5jUcMN9AY6A8k+AwjlP8GIOURxaEVOiqVYS5HkneZb9Df0Js7p35mG9UkvXNbOdCylWt2/PA9xKmzCy3QeZf51cMd1rrUTRsG6RfMsao+/SN/jxO3sI0lZOaftvBrUYcQj9g5cS+2dY=
+  - secure: j0kMxz+4eK+lf76y97XJj+TwgSIQf6RA1Hzvp/vhDVtBmyqYDMFl3U78gOgGhxHNeDH/E7IRQnA+lT1Ra/a1HrBT3LcgQJ1DwWRu2A6uvkZ1cuqsm8I1Kzb3sRi5W06wMjxRdDtbB+1XuotiR9R6eKtTDztPugswySGAj84cYKfdlJBt+a/eZWaOupZYXxgPO3A3iX8XZbqOBWIozKjlDsdbeI690mp+Cdh49WknCB0wCYpcUmyV1uUzWGG03VnbjH7lcCQIaUQTUCcJoJcEITDidC6+9FAwovMOcK8BX1DYiZfaOz59peDjMB5NO4KZel37EWcPC2CRFmjHLszR2dy3LaIrKaIxr9HCa9Yd8MQzm9Y1PYqEwnIYA8VRNLQaRH9YGh29aQqPcMX1xeBcj5+ZWWxJQ7y0uVyMzxYVSkTNg6urHvRejXBwNx9ZpkAnfzFST/v8BcjH7x96kA4gqpSUEFdjKr0DI1+xkqsB7Ukc7efzklbI6BJ8MQ+kwyqDjjIs3qPiq3m6UiHD02ewXAcTlaudsFbEUwS1zAhoWUASc4lm8Dz3ETh5yPOzd+JVTLrAIPaK887OgaLs1qf1ItBqIA3KN4aWRUKA2o3eNIn/RMVLG6znTztPuxoY5ZYnOrO6GCkXOBacjctLyIEh+d4FbyociZTaWaqG4oVsc9w=
+script:
+- echo Building a new Docker image from source…
+- docker build --build-arg RAILS_ENV=test -t ccs-rmi-frontend:test .
+- echo Testing the newly built Docker image…
+- docker run --name pg -d -p 5455:5432 postgres
+- docker run --name test -d -e RAILS_ENV=test -e API_ROOT=https://ccs.api/ --link pg:pg ccs-rmi-frontend:test /bin/bash -c "tail -f /dev/null"
+- docker exec test bundle install --with test --retry 3 --jobs 20
+- docker exec test /bin/bash -c "export DATABASE_URL='postgres://postgres@pg:5432/test?template=template0&pool=5&encoding=unicode' && rake db:create db:schema:load"
+- docker exec test /bin/bash -c "export DATABASE_URL='postgres://postgres@pg:5432/test?template=template0&pool=5&encoding=unicode' && rake db:migrate"
+- docker exec test /bin/bash -c "export DATABASE_URL='postgres://postgres@pg:5432/test?template=template0&pool=5&encoding=unicode' && rake"
+- docker rm -f test pg
+- echo Tagging the successfully tested image as latest…
+- docker tag ccs-rmi-frontend:test thedxw/ccs-rmi-frontend:$TRAVIS_COMMIT
+after_success:
+- echo "install cloudfoundry cli"
+- wget -q -O - https://packages.cloudfoundry.org/debian/cli.cloudfoundry.org.key |
+  sudo apt-key add -
+- echo "deb https://packages.cloudfoundry.org/debian stable main" | sudo tee /etc/apt/sources.list.d/cloudfoundry-cli.list
+- sudo apt-get update -qq
+- sudo apt-get install cf-cli
 deploy:
+  - provider: script
+    script: bash CF/docker-push.sh
+    on:
+      all_branches: true
+  - provider: script
+    script: bash CF/deploy-app.sh -u $CF_USER -o $CF_ORG -p $CF_PASS -s sandbox
+    on:
+      branch: sandbox
   - provider: script
     script: bash CF/deploy-app.sh -u $CF_USER -o $CF_ORG -p $CF_PASS -s staging
     on:

--- a/CF/ccs-rmi-cdn-sandbox.json
+++ b/CF/ccs-rmi-cdn-sandbox.json
@@ -1,0 +1,1 @@
+{"domain": "api.sandbox.rmi-paas.dxw.net,www.sandbox.rmi-paas.dxw.net", "headers": ["*"]}

--- a/CF/create-cf-space.sh
+++ b/CF/create-cf-space.sh
@@ -78,8 +78,8 @@ cf install-plugin blue-green-deploy -r CF-Community
 cf create-service aws-s3-bucket default ingest-bucket-"$CF_SPACE"
 
 # create postgres services for app/api
-cf create-service postgres "$POSTGRES_SIZE" ccs-rmi-app-"$CF_SPACE"
-cf create-service postgres "$POSTGRES_SIZE" ccs-rmi-api-"$CF_SPACE"
+cf create-service postgres "$POSTGRES_SIZE" ccs-rmi-app-"$CF_SPACE" -c '{"enable_extensions": ["pgcrypto"]}'
+cf create-service postgres "$POSTGRES_SIZE" ccs-rmi-api-"$CF_SPACE" -c '{"enable_extensions": ["pgcrypto"]}'
 
 # create redit service
 cf create-service redis "$REDIS_SIZE" ccs-rmi-redis-"$CF_SPACE"

--- a/CF/create-cf-space.sh
+++ b/CF/create-cf-space.sh
@@ -9,8 +9,8 @@ usage() {
   echo "  -h                    - help"
   echo "  -u <CF_USER>          - CloudFoundry user             (required)"
   echo "  -p <CF_PASS>          - CloudFoundry password         (required)"
-  echo "  -o <CF_ORG>           - CloudFoundry org              (required)" 
-  echo "  -s <CF_SPACE>         - CloudFoundry space to create  (required)" 
+  echo "  -o <CF_ORG>           - CloudFoundry org              (required)"
+  echo "  -s <CF_SPACE>         - CloudFoundry space to create  (required)"
   echo "  -a <CF_API_ENDPOINT>  - CloudFoundry API endpoint     (default: https://api.london.cloud.service.gov.uk)"
   exit 1
 }

--- a/CF/create-cf-space.sh
+++ b/CF/create-cf-space.sh
@@ -50,7 +50,7 @@ fi
 POSTGRES_SIZE="tiny-unencrypted-10"
 REDIS_SIZE="tiny-3.2"
 
-if [[ "$CF_SPACE" == "staging" || "$CF_SPACE" == "prod" ]]; then
+if [[ "$CF_SPACE" == "sandbox" || "$CF_SPACE" == "staging" || "$CF_SPACE" == "prod" ]]; then
   echo " *********************************************"
   echo "    The '$CF_SPACE' space will be selected"
   echo "     This deploys the apps as HA with"
@@ -86,7 +86,7 @@ cf create-service redis "$REDIS_SIZE" ccs-rmi-redis-"$CF_SPACE"
 
 # create external domains for org
 set +o pipefail
-if [[ $CF_SPACE == 'staging' || $CF_SPACE == 'prod' ]]
+if [[ $CF_SPACE == 'sandbox' || $CF_SPACE == 'staging' || $CF_SPACE == 'prod' ]]
 then
   if cf domains | grep -q ${CF_SPACE}.rmi-paas.dxw.net
   then

--- a/CF/create-new-environment.md
+++ b/CF/create-new-environment.md
@@ -1,0 +1,52 @@
+# Create a new environment
+
+First provision https://docs.cloud.service.gov.uk/deploying_services/postgresql/#set-up-a-postgresql-service
+
+```
+cf create-service postgres small-ha-10 ccs-rmi-api -c '{"enable_extensions": ["pgcrypto"]}'
+```
+
+manifest.yml must be bound to all services
+
+Create a CDN file in the frontend's CF directory for the new routing
+
+Allow your environment name as a trusted environment to the if conditions in CF/create-cf-space.sh script.
+
+```
+./create-cf-space.sh -u <YOUR_PAAS_EMAIL> -p '<YOUR_PAAS_PASSWORD>' -o ccs-report-management-info -s sandbox
+```
+
+This outputs some CDN configuration that we need to share with dxw's DNS by deploying a change to this file https://git.govpress.com/ops/BytemarkDNS/blob/master/data/dxw.net#L755:
+
+```
+status:    create in progress
+message:   Provisioning in progress
+           [api.sandbox.rmi-paas.dxw.net,www.sandbox.rmi-paas.dxw.net =>
+           london.cloudapps.digital]; CNAME or ALIAS domain
+           api.sandbox.rmi-paas.dxw.net,www.sandbox.rmi-paas.dxw.net to
+           d1ltkl96cllw58.cloudfront.net and create TXT record(s):
+name:
+           _acme-challenge.api.sandbox.rmi-paas.dxw.net., value:
+           xxx, ttl: 120
+name:
+           _acme-challenge.www.sandbox.rmi-paas.dxw.net., value:
+           xxx, ttl: 120
+started:   2019-08-15T10:01:15Z
+updated:   2019-08-15T10:01:17Z
+```
+
+The CDN service will be stuck with a `provisioning` status until this change is deployed: https://git.govpress.com/ops/BytemarkDNS/merge_requests/102/diffs
+
+When the database is created for the first time for both API and Frontend, there will be Postgres permission errors that prevent the apps from starting. We believe that this is because the Database has already been created, but the schema has not been loaded. To get around this you can follow these steps or do a database restore.
+
+1. remove `rake db:create` from the docker-entrypoint.sh  
+2. build a new docker image locally with this change `docker build . -t thedxw/ccs-rmi-api:pg-fix`
+3. push this docker image to the docker repository `docker push thedxw/ccs-rmi-api:pg-fix`
+4. deploy this change to gpaas `cf v3-zdt-push ccs-rmi-api-"$CF_SPACE" --docker-image thedxw/ccs-rmi-api:pg-fix`
+5. check the logs to see if Puma started `cf logs ccs-rmi-api --recent`
+
+You need to add some additional routing in order to all users access of the /admin section of the API, which is otherwise thought of as a "private" application within gpaas.
+
+https://github.com/dxw/DataSubmissionService/pull/238/files
+
+There is also a router service that you will need to deploy. Check this out locally, allow the new space name in the if conditions and deploy the app from your local machine using the CF/deploy script: https://github.com/dxw/DataSubmissionServiceRouter

--- a/CF/deploy-app.sh
+++ b/CF/deploy-app.sh
@@ -120,7 +120,7 @@ sed "s/CF_SPACE/$CF_SPACE/g" manifest-template.yml | sed "s/MEMORY_LIMIT/$MEMORY
 cd .. || exit
 
 # create an app idempotently with the v3 cli
-cf v3-create-app ccs-rmi-frontend-"$CF_SPACE"
+cf v3-create-app ccs-rmi-frontend-"$CF_SPACE" --app-type docker
 cf v3-apply-manifest -f CF/"$CF_SPACE".manifest.yml
 # do a zero down time deployment with the v3 cli
-cf v3-zdt-push ccs-rmi-frontend-"$CF_SPACE"
+cf v3-zdt-push ccs-rmi-frontend-"$CF_SPACE" --docker-image thedxw/ccs-rmi-frontend:$TRAVIS_COMMIT

--- a/CF/deploy-app.sh
+++ b/CF/deploy-app.sh
@@ -120,7 +120,7 @@ sed "s/CF_SPACE/$CF_SPACE/g" manifest-template.yml | sed "s/MEMORY_LIMIT/$MEMORY
 cd .. || exit
 
 # create an app idempotently with the v3 cli
-cf v3-create-app ccs-rmi-app-"$CF_SPACE"
+cf v3-create-app ccs-rmi-frontend-"$CF_SPACE"
 cf v3-apply-manifest -f CF/"$CF_SPACE".manifest.yml
 # do a zero down time deployment with the v3 cli
-cf v3-zdt-push ccs-rmi-app-"$CF_SPACE"
+cf v3-zdt-push ccs-rmi-frontend-"$CF_SPACE"

--- a/CF/deploy-app.sh
+++ b/CF/deploy-app.sh
@@ -94,7 +94,7 @@ then
   fi
 fi
 
-if [[ "$CF_SPACE" == "staging" || "$CF_SPACE" == "prod" ]]; then
+if [[ "$CF_SPACE" == "sandbox" || "$CF_SPACE" == "staging" || "$CF_SPACE" == "prod" ]]; then
   echo " *********************************************"
   echo "    The '$CF_SPACE' space will be selected"
   echo "     This deploys the apps as HA with"

--- a/CF/deploy-app.sh
+++ b/CF/deploy-app.sh
@@ -9,11 +9,11 @@ usage() {
   echo "  -h                    - help"
   echo "  -u <CF_USER>          - CloudFoundry user             (required)"
   echo "  -p <CF_PASS>          - CloudFoundry password         (required)"
-  echo "  -o <CF_ORG>           - CloudFoundry org              (required)" 
-  echo "  -s <CF_SPACE>         - CloudFoundry space to target  (required)" 
+  echo "  -o <CF_ORG>           - CloudFoundry org              (required)"
+  echo "  -s <CF_SPACE>         - CloudFoundry space to target  (required)"
   echo "  -a <CF_API_ENDPOINT>  - CloudFoundry API endpoint     (default: https://api.london.cloud.service.gov.uk)"
   echo "  -f                    - Force a deploy of a non standard branch to staging or prod"
-  
+
   exit 1
 }
 
@@ -82,7 +82,7 @@ then
       exit 1
     fi
   fi
-  
+
   if [[ "$CF_SPACE" == "prod" ]]
   then
     if [[ ! "$BRANCH" == "master" ]]
@@ -106,8 +106,6 @@ if [[ "$CF_SPACE" == "staging" || "$CF_SPACE" == "prod" ]]; then
   MEMORY_LIMIT="512M"
   INSTANCE_COUNT="3"
 fi
-
-
 
 cd "$SCRIPT_PATH" || exit
 

--- a/CF/docker-push.sh
+++ b/CF/docker-push.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+docker push thedxw/ccs-rmi-frontend:$TRAVIS_COMMIT
+echo "Pushed new Docker image to Docker Hub…"

--- a/CF/manifest-template.yml
+++ b/CF/manifest-template.yml
@@ -2,6 +2,7 @@
 applications:
   - name: ccs-rmi-app-CF_SPACE
     memory: MEMORY_LIMIT
+    disk_quota: 2048M
     instances: INSTANCE_COUNT
     services:
       - ccs-rmi-app-CF_SPACE

--- a/CF/manifest-template.yml
+++ b/CF/manifest-template.yml
@@ -19,5 +19,3 @@ applications:
       RACK_ENV: production
       RAILS_SERVE_STATIC_FILES: enabled
       CORRECTION_RETURNS_ENABLED: true
-
-

--- a/CF/manifest-template.yml
+++ b/CF/manifest-template.yml
@@ -1,6 +1,6 @@
 ---
 applications:
-  - name: ccs-rmi-app-CF_SPACE
+  - name: ccs-rmi-frontend-CF_SPACE
     memory: MEMORY_LIMIT
     disk_quota: 2048M
     instances: INSTANCE_COUNT

--- a/CF/manifest-template.yml
+++ b/CF/manifest-template.yml
@@ -19,3 +19,4 @@ applications:
       RACK_ENV: production
       RAILS_SERVE_STATIC_FILES: enabled
       CORRECTION_RETURNS_ENABLED: true
+    command: bash -c "rm -f tmp/pids/server.pid && rails s"

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -11,7 +11,7 @@ services:
       DATABASE_URL: "postgres://postgres@db-test:5432/DataSubmissionService_test?template=template0&pool=5&encoding=unicode"
       API_ROOT: "https://ccs.api/"
     env_file:
-      - docker-compose.env
+      - docker-compose.env.sample
     volumes:
       - .:/srv/dss:cached
       - node_modules:/srv/dss/node_modules


### PR DESCRIPTION
## Changes in this PR:

This deployment comes in a pair with a similar change made to the frontend: https://github.com/dxw/DataSubmissionServiceAPI/pull/504

- deploy the Rails application to PaaS through containers rather than Rails buildpacks
- provision and support a new `sandbox` environment to enable the testing of this feature. Providing it remains stable and unchanged it can be viewed here: https://www.sandbox.rmi-paas.dxw.net
- given that our deployment scripts for setting up environments in paas live in this repo, this proposal will include some changes that help provision to complimentary work to enable deployment of the API through containers. General documentation and notes have been added to help with the process next time
- Travis (CI) is now responsible for building, testing and deploying the same artefact (in our case a docker image) for us
- A new public docker repository exists https://cloud.docker.com/u/thedxw/repository/docker/thedxw/ccs-rmi-frontend and our `dxwempire` has permission to push new images
- Application name changed on the PaaS from `ccs-rmi-app-sandbox` to `ccs-rmi-frontend-sandbox` for clarity where the term "app" is being overused between PaaS "apps" and Rails "apps", making it hard to understand at first. This also matches the new docker repo name for consistency.
- Fix/update the installation process for postgres to ensure required extensions are provisioned automatically when a new space is created

A sandbox branch now exists which currently has this code checked out. Making a change there should automatically change the application running on https://www.sandbox.rmi-paas.dxw.net - I recommend testing by changing some copy on the landing page.