### PR TITLE
[1140] Handle the new management_charge_calculation_failed submission status

### DIFF
--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -18,7 +18,7 @@ class SubmissionsController < ApplicationController
     @submission = API::Submission.includes(:files).find(params[:id]).first
     @file = @submission.files&.first
 
-    render template_for_submission(@submission)
+    render template_for_submission(@submission), status: status_for_submission(@submission)
   end
 
   def download
@@ -64,12 +64,17 @@ class SubmissionsController < ApplicationController
   end
 
   def template_for_submission(submission)
+    case (status = submission.status)
+    when 'pending' then 'processing'
+    when 'management_charge_calculation_failed' then 'errors/internal_server_error'
+    else status
+    end
+  end
+
+  def status_for_submission(submission)
     case submission.status
-    when 'pending', 'processing' then :processing
-    when 'in_review' then :in_review
-    when 'validation_failed' then :validation_failed
-    when 'ingest_failed' then :ingest_failed
-    when 'completed' then :completed
+    when 'management_charge_calculation_failed' then :internal_server_error
+    else :ok
     end
   end
 

--- a/app/models/api/task.rb
+++ b/app/models/api/task.rb
@@ -12,7 +12,7 @@ module API
     end
 
     def errors?
-      %w[validation_failed ingest_failed].include?(active_submission&.status) || false
+      %w[validation_failed ingest_failed management_charge_calculation_failed].include?(active_submission&.status)
     end
 
     def late?

--- a/app/views/tasks/_submission_buttons.html.haml
+++ b/app/views/tasks/_submission_buttons.html.haml
@@ -1,7 +1,7 @@
 - case submission.status
 - when 'pending', 'processing'
     = link_to 'View progress', task_submission_path(task_id: task.id, id: submission.id), {class: 'govuk-button', 'aria-label' => "View progress of this task"}
-- when 'validation_failed', 'ingest_failed'
+- when 'validation_failed', 'ingest_failed', 'management_charge_calculation_failed'
     = link_to 'View errors', task_submission_path(task_id: task.id, id: submission.id, correction: task.correcting?), {class: 'govuk-button', 'aria-label' => "View the errors for this task"}
     = link_to 'Upload amended file', new_task_submission_path(task_id: task.id, correction: task.correcting?), {class: 'govuk-button', 'aria-label' => "Upload an amended file for this task"}
 - when 'in_review'

--- a/spec/fixtures/mocks/incomplete_tasks_with_framework_and_active_submission.json
+++ b/spec/fixtures/mocks/incomplete_tasks_with_framework_and_active_submission.json
@@ -190,6 +190,45 @@
       }
     },
     {
+      "id": "b847e0f7-027e-4b95-afa2-3490b8d05a1e",
+      "type": "tasks",
+      "attributes": {
+        "status": "in_progress",
+        "framework_id": "7a50a178-3fb8-4c0a-9f2c-8841812448d1",
+        "supplier_id": "533a1357-4faf-4ced-b759-3e6da0bc5f3e",
+        "supplier_name": "Bobs Cheese Shop",
+        "description": null,
+        "due_on": "2018-08-07",
+        "period_year": 2018,
+        "period_month": 7
+      },
+      "relationships": {
+        "active_submission": {
+          "data": {
+            "type": "submissions",
+            "id": "43dfbd10-1c17-4f3c-8665-ae8c2776249b"
+          }
+        },
+        "latest_submission": {
+          "data": {
+            "type": "submissions",
+            "id": "43dfbd10-1c17-4f3c-8665-ae8c2776249b"
+          }
+        },
+        "submissions": {
+          "meta": {
+            "included": false
+          }
+        },
+        "framework": {
+          "data": {
+            "type": "frameworks",
+            "id": "7a50a178-3fb8-4c0a-9f2c-8841812448d1"
+          }
+        }
+      }
+    },
+    {
       "id": "b847e0f7-027e-4b95-afa2-3490b8d05a1d",
       "type": "tasks",
       "attributes": {
@@ -417,6 +456,36 @@
       "type": "submissions",
       "attributes": {
         "status": "completed",
+        "submitted_at": null
+      },
+      "relationships": {
+        "framework": {
+          "meta": {
+            "included": false
+          }
+        },
+        "task": {
+          "meta": {
+            "included": false
+          }
+        },
+        "entries": {
+          "meta": {
+            "included": false
+          }
+        },
+        "files": {
+          "meta": {
+            "included": false
+          }
+        }
+      }
+    },
+    {
+      "id": "43dfbd10-1c17-4f3c-8665-ae8c2776249b",
+      "type": "submissions",
+      "attributes": {
+        "status": "management_charge_calculation_failed",
         "submitted_at": null
       },
       "relationships": {

--- a/spec/fixtures/mocks/submission_management_charge_calculation_failed.json
+++ b/spec/fixtures/mocks/submission_management_charge_calculation_failed.json
@@ -1,0 +1,47 @@
+{
+  "data": {
+    "id": "9a5ef62c-0781-4f80-8850-5793652b6b40",
+    "type": "submissions",
+    "attributes": {
+      "framework_id": "f87717d4-874a-43d9-b99f-c8cf2897b526",
+      "supplier_id": "cd40ead8-67b5-4918-abf0-ab8937cd04ff",
+      "task_id": "2d98639e-5260-411f-a5ee-61847a2e067c",
+      "sheet_errors": {
+        "InvoicesRaised": [
+          { "message": "Enter value, without commas or pound signs", "location": { "row": 1, "column": "Price per Unit" } },
+          { "message": "You must enter a valid URN", "location": { "row": 2, "column": "Customer URN" } }
+        ],
+        "OrdersReceived": []
+      },
+      "invoice_count": 2,
+      "order_count": 1,
+      "order_total_value": "1000.0",
+      "invoices_total_value": "2000.0",
+      "purchase_order_number": null,
+      "status": "management_charge_calculation_failed"
+    },
+    "relationships": {
+      "files": {
+        "data": [
+          {
+            "type": "submission_files",
+            "id": "8d0e4289-5fde-4faa-b78e-922846d8460a"
+          }
+        ]
+      }
+    }
+  },
+  "included": [
+    {
+      "id": "8d0e4289-5fde-4faa-b78e-922846d8460a",
+      "type": "submission_files",
+      "attributes": {
+        "submission_id": "9a5ef62c-0781-4f80-8850-5793652b6b40",
+        "temporary_download_url": "http://s3.example.com/example.xls",
+        "filename": "example.xls",
+        "rows": 3
+      }
+    }
+  ]
+}
+

--- a/spec/fixtures/mocks/task_with_submission_that_failed_management_charge_calculation.json
+++ b/spec/fixtures/mocks/task_with_submission_that_failed_management_charge_calculation.json
@@ -1,0 +1,37 @@
+{
+  "data": {
+    "id": "2d98639e-5260-411f-a5ee-61847a2e067c",
+    "type": "tasks",
+    "attributes": {
+      "description": "test task",
+      "due_on": "2030-01-01",
+      "period_month": 7,
+      "period_year": 2018,
+      "status": "unstarted",
+      "framework_id": "f87717d4-874a-43d9-b99f-c8cf2897b526",
+      "supplier_id": "cd40ead8-67b5-4918-abf0-ab8937cd04ff",
+      "supplier_name": "Bobs Cheese Shop"
+    },
+    "relationships": {
+      "active_submission": {
+        "data": {
+          "type": "submissions",
+          "id": "63996088-5c20-4e65-b722-287fafeedc97"
+        }
+      }
+    }
+  },
+  "included": [
+    {
+      "id": "63996088-5c20-4e65-b722-287fafeedc97",
+      "type": "submissions",
+      "attributes": {
+        "framework_id": "f87717d4-874a-43d9-b99f-c8cf2897b526",
+        "supplier_id": "cd40ead8-67b5-4918-abf0-ab8937cd04ff",
+        "task_id": "2d98639e-5260-411f-a5ee-61847a2e067c",
+        "status": "management_charge_calculation_failed"
+      }
+    }
+  ]
+}
+

--- a/spec/models/api/task_spec.rb
+++ b/spec/models/api/task_spec.rb
@@ -25,6 +25,13 @@ RSpec.describe API::Task do
       expect(task_with_invalid_submission.errors?).to be_truthy
     end
 
+    it 'returns true if the latest submission failed to have its management charge calculated' do
+      mock_task_with_submission_that_failed_management_charge_calculation_endpoint!
+      task_with_invalid_submission = API::Task.includes(:active_submission).find(mock_task_id).first
+
+      expect(task_with_invalid_submission.errors?).to be_truthy
+    end
+
     it 'returns false if the latest submission is not errored' do
       mock_task_with_valid_submission_endpoint!
       task_with_valid_submission = API::Task.includes(:active_submission).find(mock_task_id).first

--- a/spec/requests/submissions_spec.rb
+++ b/spec/requests/submissions_spec.rb
@@ -51,6 +51,14 @@ RSpec.describe 'the submission page' do
       expect(response.body).to include 'Enter value, without commas or pound signs'
     end
 
+    it 'displays the 500 page for a submission that failed management charge calculation' do
+      mock_submission_management_charge_calculation_failed_endpoint!
+      get task_submission_path(task_id: mock_task_id, id: mock_submission_id)
+
+      expect(response).to have_http_status(500)
+      expect(response.body).to include 'Sorry, there is a problem with the service'
+    end
+
     it 'shows completed submission page for a "completed" submission' do
       mock_submission_completed_no_business_endpoint!
       mock_user_endpoint!

--- a/spec/requests/tasks_spec.rb
+++ b/spec/requests/tasks_spec.rb
@@ -42,8 +42,17 @@ RSpec.describe 'the tasks list' do
       end
     end
 
-    it 'includes links to view or amend a failed submission' do
+    it 'includes links to view or amend a validation_failed submission' do
       errored_task_id = 'b847e0f7-027e-4b95-afa2-3490b8d05a1c'
+
+      assert_select "#task-#{errored_task_id}" do
+        assert_select 'a', text: 'View errors'
+        assert_select 'a', text: 'Upload amended file'
+      end
+    end
+
+    it 'includes links to view or amend a management_charge_calculation_failed submission' do
+      errored_task_id = 'b847e0f7-027e-4b95-afa2-3490b8d05a1e'
 
       assert_select "#task-#{errored_task_id}" do
         assert_select 'a', text: 'View errors'

--- a/spec/support/api_helpers.rb
+++ b/spec/support/api_helpers.rb
@@ -62,6 +62,11 @@ module ApiHelpers
       .to_return(headers: json_headers, body: json_fixture_file('submission_errored.json'))
   end
 
+  def mock_submission_management_charge_calculation_failed_endpoint!
+    stub_request(:get, api_url("submissions/#{mock_submission_id}?include=files"))
+      .to_return(headers: json_headers, body: json_fixture_file('submission_management_charge_calculation_failed.json'))
+  end
+
   def mock_submission_completed_no_business_endpoint!
     stub_request(:get, api_url("submissions/#{mock_submission_id}?include=files"))
       .to_return(headers: json_headers, body: json_fixture_file('submission_completed_no_business.json'))
@@ -177,6 +182,12 @@ module ApiHelpers
   def mock_task_with_submission_that_failed_ingest_endpoint!
     stub_request(:get, api_url("tasks/#{mock_task_id}?include=active_submission"))
       .to_return(headers: json_headers, body: json_fixture_file('task_with_submission_that_failed_ingest.json'))
+  end
+
+  def mock_task_with_submission_that_failed_management_charge_calculation_endpoint!
+    stub_request(:get, api_url("tasks/#{mock_task_id}?include=active_submission"))
+      .to_return(headers: json_headers,
+                 body: json_fixture_file('task_with_submission_that_failed_management_charge_calculation.json'))
   end
 
   def mock_task_with_valid_submission_endpoint!


### PR DESCRIPTION
## Changes in this PR:

- Handle the new (edge case) `management_charge_calculation_failed` submission status, added to the API in dxw/DataSubmissionServiceAPI#505. Display a generic error message and return a 500 status if the user tries to view the details of the errors (see commit message for further justification).

## Screenshots of UI changes:

### After

Error page displayed when trying to view a submission with this status:

![frontend-error](https://user-images.githubusercontent.com/53756884/63422764-eb68bf80-c402-11e9-9676-fe4b5423f8df.png)