### PR TITLE
Bump nokogiri to v1.10.4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -55,6 +55,9 @@ gem 'skylight'
 # Auth0 client for user setup scripts
 gem 'auth0', require: false
 
+# Force non-vulnerable version of Nokogiri
+gem 'nokogiri', '>= 1.10.4'
+
 group :development, :test do
   gem 'brakeman', require: false
   gem 'byebug', platforms: %i[mri mingw x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -359,6 +359,7 @@ DEPENDENCIES
   listen (>= 3.0.5, < 3.2)
   lograge
   mini_racer
+  nokogiri (>= 1.10.4)
   omniauth
   omniauth-auth0 (~> 2.0.0)
   omniauth-rails_csrf_protection
@@ -383,4 +384,4 @@ RUBY VERSION
    ruby 2.5.5p157
 
 BUNDLED WITH
-   2.0.1
+   2.0.2


### PR DESCRIPTION
Previous version were vulnerable - see https://nvd.nist.gov/vuln/detail/CVE-2019-5477 for details

NB: running `bundle update nokogiri` failed, so fixed by explicitly declaring a minimum version in Gemfile.
