### PR TITLE
Revert "Merge pull request #275 from dxw/security/update-nokogiri"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -55,9 +55,6 @@ gem 'skylight'
 # Auth0 client for user setup scripts
 gem 'auth0', require: false
 
-# Force non-vulnerable version of Nokogiri
-gem 'nokogiri', '>= 1.10.4'
-
 group :development, :test do
   gem 'brakeman', require: false
   gem 'byebug', platforms: %i[mri mingw x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -359,7 +359,6 @@ DEPENDENCIES
   listen (>= 3.0.5, < 3.2)
   lograge
   mini_racer
-  nokogiri (>= 1.10.4)
   omniauth
   omniauth-auth0 (~> 2.0.0)
   omniauth-rails_csrf_protection
@@ -384,4 +383,4 @@ RUBY VERSION
    ruby 2.5.5p157
 
 BUNDLED WITH
-   2.0.2
+   2.0.1


### PR DESCRIPTION
## Changes in this PR:

This reverts commit dcc27893ecac2d44dd8e04c06cc6bc5342a0a5bc, reversing
changes made to 238ea3f1ce2020a9d85403f4897ca5c81e02ad41.

Whilst we have already merged a fix for this Nokogiri vulnerability https://github.com/dxw/DataSubmissionService/pull/270 we attempted another change because the GitHub security advisory was still displaying on the repository page, and we had received another warning email. We also believe that the changes made in this change better protect the team from accidentally reverting back to a vulnerable version of Nokogiri due tot he explicit lock `'>= 1.10.4'`.


Updating the Nokogiri gem using bundler 2.0.2 was fine during the the build phase and so was merged. However, when CI came to deploy this change the Ruby on Rails buildpack was using bundler 2.0.1 which fails the deployment:
 
![Screenshot 2019-08-21 at 17 48 14](https://user-images.githubusercontent.com/912473/63451620-8c27a100-c43c-11e9-83c9-a24a6e9b5cff.png)

Whilst we need a more solid answer to how to upgrade bundler versions, we should for now unblock the deployment pipelines to enable us to continue delivering features and other security fixes.