### PR TITLE
Release 53

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## [release-53] - 2019-08-22
+
+- Handle the new management_charge_calculation_failed submission status
+- [Security] Bump nokogiri from 1.10.3 to 1.10.4
+- Add the correction param to view errors button
+
 ## [release-52] - 2019-08-13
 
 - Allow suppliers to download submissions from S3
@@ -281,6 +287,7 @@
 
 Initial release
 
+[release-53]: https://github.com/dxw/DataSubmissionService/compare/release-52...release-53
 [release-52]: https://github.com/dxw/DataSubmissionService/compare/release-51...release-52
 [release-51]: https://github.com/dxw/DataSubmissionService/compare/release-50...release-51
 [release-50]: https://github.com/dxw/DataSubmissionService/compare/release-49...release-50


### PR DESCRIPTION
- Handle the new management_charge_calculation_failed submission status
- [Security] Bump nokogiri from 1.10.3 to 1.10.4
- Add the correction param to view errors button