### PR TITLE
[1096] Add some security-related HTTP response headers

### DIFF
--- a/app/assets/javascripts/main.js
+++ b/app/assets/javascripts/main.js
@@ -1,4 +1,7 @@
 window.onload = function() {
+  // From the govuk-frontend template.njk
+  document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
+
   window.GOVUKFrontend.initAll()
 };
 

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -18,9 +18,6 @@
     = render('shared/analytics') if ENV['GOOGLE_TAG_MANAGER_ID']
 
   %body.govuk-template__body.app-body-class
-    %script
-      document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
-
     %a{ href: '#main-content', class: 'govuk-skip-link' }
       Skip to main content
 

--- a/app/views/layouts/errors.html.haml
+++ b/app/views/layouts/errors.html.haml
@@ -18,9 +18,6 @@
     = render('shared/analytics') if ENV['GOOGLE_TAG_MANAGER_ID']
 
   %body.govuk-template__body.app-body-class
-    %script
-      document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
-
     %a{ href: '#main-content', class: 'govuk-skip-link' }
       Skip to main content
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -104,6 +104,8 @@ Rails.application.configure do
 
   config.action_dispatch.default_headers.merge!(
     # Value given by https://www.gov.uk/service-manual/technology/using-https
-    'Strict-Transport-Security' => 'max-age=31536000, includeSubDomains; preload;'
+    'Strict-Transport-Security' => 'max-age=31536000, includeSubDomains; preload;',
+
+    'Expect-CT' => 'enforce, max-age=10'
   )
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -101,4 +101,9 @@ Rails.application.configure do
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
+
+  config.action_dispatch.default_headers.merge!(
+    # Value given by https://www.gov.uk/service-manual/technology/using-https
+    'Strict-Transport-Security' => 'max-age=31536000, includeSubDomains; preload;'
+  )
 end

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -4,17 +4,20 @@
 # For further information see the following documentation
 # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy
 
-# Rails.application.config.content_security_policy do |policy|
-#   policy.default_src :self, :https
-#   policy.font_src    :self, :https, :data
-#   policy.img_src     :self, :https, :data
-#   policy.object_src  :none
-#   policy.script_src  :self, :https
-#   policy.style_src   :self, :https
+Rails.application.config.content_security_policy do |policy|
+  policy.default_src :self
 
-#   # Specify URI for violation reports
-#   # policy.report_uri "/csp-violation-report-endpoint"
-# end
+  policy.style_src   :self, 'https://fonts.googleapis.com'
+  # For loading fonts referenced by the aforementioned styles
+  # (https://fonts.gstatic.com at time of writing, but I see nothing to
+  # suggest we can hardcode this host)
+  policy.font_src    :self, :https
+
+  # script-src and img-src settings required for Google Tag Manager:
+  # https://developers.google.com/tag-manager/web/csp
+  policy.script_src :self, :unsafe_inline, 'https://www.googletagmanager.com'
+  policy.img_src    :self, 'https://www.googletagmanager.com'
+end
 
 # If you are using UJS then enable automatic nonce generation
 # Rails.application.config.content_security_policy_nonce_generator = -> request { SecureRandom.base64(16) }


### PR DESCRIPTION
## Changes in this PR:

Add the following response headers:
- `Strict-Transport-Security` - lets a web site tell browsers that it should only be accessed using HTTPS, instead of using HTTP.
- `Content-Security-Policy` -  restricts the locations from which a browser will download or execute resources such as images, scripts, etc. It does this using a per-response whitelist. An additional layer of defence against attacks such as cross-site scripting.
- `Expect-CT` - tells the browser that if communicating with a web site over HTTPS, then the certificate presented by the web site must meet Certificate Transparency requirements. This means that the certificate must have been added to a public log.

_See commit messages for more details._

## Motivation:

My understanding, from our discussion of the original ticket, is that this list of "missing" headers was the result of some sort of pen test of the service. It seems to me that they are all sensible headers to add. In addition, the Service Manual states that `Strict-Transport-Security` should be returned.

## WARNING

1. It is not easy to test the HTTPS-related headers (`Strict-Transport-Security`, `Expect-CT`) in development, since we do not use HTTPS for development. We will need to test on staging before deploying to production.
2. We must get permission from CCS to enable the `includeSubDomains` directive to `Strict-Transport-Security` before deploying to production.