### PR TITLE
[1096] (fix) Fix Google Analytics by expanding Content-Security-Policy whitelist

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -13,10 +13,12 @@ Rails.application.config.content_security_policy do |policy|
   # suggest we can hardcode this host)
   policy.font_src    :self, :https
 
-  # script-src and img-src settings required for Google Tag Manager:
+  # script-src and img-src settings required for Google Tag Manager;
+  # script-src, img-src, and connect-src settings required for Google Analytics:
   # https://developers.google.com/tag-manager/web/csp
-  policy.script_src :self, :unsafe_inline, 'https://www.googletagmanager.com'
-  policy.img_src    :self, 'https://www.googletagmanager.com'
+  policy.script_src  :self, :unsafe_inline, 'https://www.googletagmanager.com', 'https://www.google-analytics.com', 'https://ssl.google-analytics.com'
+  policy.img_src     :self, 'https://www.googletagmanager.com', 'https://www.google-analytics.com'
+  policy.connect_src :self, 'https://www.google-analytics.com'
 end
 
 # If you are using UJS then enable automatic nonce generation


### PR DESCRIPTION
With the Content-Security-Policy response header introduced in bc12b64,
I broke Google Analytics on production. It is able to load the script
from the whitelisted https://www.googletagmanager.com, but it turns out
that this script then attempts to load another script from
https://www.google-analytics.com.

This is the error that Chrome gives me:

gtm.js?id=GTM-TQNKLQS:361 Refused to load the script 'https://www.google-analytics.com/analytics.js' because it violates the following Content Security Policy directive: "script-src 'self' 'unsafe-inline' https://www.googletagmanager.com". Note that 'script-src-elem' was not explicitly set, so 'script-src' is used as a fallback.

I think I misread the (linked) documentation and assumed that you had to
_either_ whitelist the Google Tag Manager sources or the Google
Analytics sources. Looks like you might need to whitelist both.

Unfortunately we don't have any testing environment for Google Tag
Manager or Analytics, so will need to deploy this to prod again and see
if it fixes things.
