### PR TITLE
Change survey URL

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -20,6 +20,6 @@ module ApplicationHelper
   end
 
   def survey_url
-    'https://www.surveymonkey.com/r/9QTDW9P'
+    'https://www.smartsurvey.co.uk/s/YF7CY/'
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -18,4 +18,8 @@ module ApplicationHelper
   def correction_returns_enabled?
     ENV['CORRECTION_RETURNS_ENABLED'].present?
   end
+
+  def survey_url
+    'https://www.surveymonkey.com/r/9QTDW9P'
+  end
 end

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -30,7 +30,7 @@
             beta
           %span.govuk-phase-banner__text
             This is a new service – your
-            %a.govuk-link{:href => "https://www.surveymonkey.com/r/9QTDW9P"} feedback
+            %a.govuk-link{:href => survey_url} feedback
             will help us to improve it.
 
     .govuk-width-container

--- a/app/views/layouts/errors.html.haml
+++ b/app/views/layouts/errors.html.haml
@@ -30,7 +30,7 @@
             beta
           %span.govuk-phase-banner__text
             This is a new service – your
-            %a.govuk-link{:href => "https://www.surveymonkey.com/r/9QTDW9P"} feedback
+            %a.govuk-link{:href => survey_url} feedback
             will help us to improve it.
 
     .govuk-width-container

--- a/app/views/support/index.html.haml
+++ b/app/views/support/index.html.haml
@@ -30,7 +30,7 @@
     %p
       If you have a general question about the service, please contact the team at the same address, including ‘general question’ in the subject line of your email.
     %p
-      To tell us about your experience of the service you can complete our <a href="https://www.surveymonkey.com/r/9QTDW9P">short feedback survey</a>. Alternatively contact the team on
+      To tell us about your experience of the service you can complete our <a href=#{survey_url}>short feedback survey</a>. Alternatively contact the team on
       = mail_to support_email_address
       with ‘feedback’ in the subject line of your email.
 


### PR DESCRIPTION
Change the survey URL, as requested in a support ticket. Whilst I'm at it, I've DRYed it up so we only specify the URL in one place.