### PR TITLE
Accessibility tweaks to processing page

### DIFF
--- a/app/assets/stylesheets/components/_all.scss
+++ b/app/assets/stylesheets/components/_all.scss
@@ -26,3 +26,4 @@
 @import "actions/all";
 @import "return/return";
 @import "report-table/report-table";
+@import "flash/flash";

--- a/app/assets/stylesheets/components/flash/_flash.scss
+++ b/app/assets/stylesheets/components/flash/_flash.scss
@@ -1,0 +1,14 @@
+%govuk-flash {
+  padding: $govuk-gutter-half;
+  margin-bottom: $govuk-gutter;
+  border: 5px solid;
+  font-weight: 700;
+}
+
+.govuk-flash {
+  &__notice {
+    @extend %govuk-flash;
+    color: govuk-colour("secondary");
+    border-color: govuk-colour("secondary");
+  }
+}

--- a/app/views/submissions/processing.html.haml
+++ b/app/views/submissions/processing.html.haml
@@ -1,6 +1,6 @@
 - page_title "Checking file: Report management information for #{@task.reporting_period} on #{@task.framework.short_name}"
 
-= content_for(:head, tag.meta('http-equiv': 'refresh', content: 5))
+= content_for(:head, tag.meta('http-equiv': 'refresh', content: 10))
 
 .govuk-grid-row
   .govuk-grid-column-full

--- a/app/views/submissions/processing.html.haml
+++ b/app/views/submissions/processing.html.haml
@@ -4,6 +4,14 @@
 
 .govuk-grid-row
   .govuk-grid-column-full
+    .govuk-flash__notice.govuk-body-m
+      Your file is being checked. You do not have to stay on this page.
+      %br
+      %br
+      Your task will be updated as this progresses.
+
+.govuk-grid-row
+  .govuk-grid-column-full
     = render 'shared/task_signpost', task: @task
 
 .govuk-grid-row
@@ -14,11 +22,3 @@
       = render partial: 'shared/this_is_a_correction' if correction?
 
   = render 'shared/progress_indicator'
-
-.govuk-grid-row
-  .govuk-grid-column-two-thirds
-    %p
-      Your file is being checked. You do not have to stay on this page.
-
-    %p
-      Your task will be updated as this progresses.


### PR DESCRIPTION
Following an accessibility audit, we've been asked to make some small changes to the processing page, namely increasing the refresh timeout (presumably so screenreaders have time to read the content of the page before it refreshes) and moving the note about what is happening further up the page. Going by the HTML, I don't think this will break anything, but I can't run the application properly to confirm this. I'd be grateful if someone with more experience than me could review this for me 😄 