### PR TITLE
(1183) Add an other section to the submitted return summary

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -80,6 +80,7 @@ group :test do
   gem 'capybara', require: false
   gem 'climate_control'
   gem 'database_cleaner'
+  gem 'launchy'
   gem 'poltergeist'
   gem 'webmock'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -139,6 +139,8 @@ GEM
       faraday (>= 0.9)
       faraday_middleware
     jwt (1.5.6)
+    launchy (2.4.3)
+      addressable (~> 2.3)
     libv8 (6.7.288.46.1)
     libv8 (6.7.288.46.1-x86_64-darwin-17)
     libv8 (6.7.288.46.1-x86_64-darwin-18)
@@ -353,6 +355,7 @@ DEPENDENCIES
   httparty
   jbuilder (~> 2.5)
   jsonapi-consumer (~> 1.0)
+  launchy
   listen (>= 3.0.5, < 3.2)
   lograge
   mini_racer
@@ -380,4 +383,4 @@ RUBY VERSION
    ruby 2.5.7p206
 
 BUNDLED WITH
-   2.0.2
+   2.1.4

--- a/app/views/shared/_submission_table.html.haml
+++ b/app/views/shared/_submission_table.html.haml
@@ -8,17 +8,23 @@
       %th.govuk-table__header.govuk-table__header--numeric{ scope: 'col' } Total
 
   %tbody.govuk-table__body
-    %tr.govuk-table__row
-      %th.govuk-table__header{ scope: 'row' }
-        Contracts
-      %td.govuk-table__cell.govuk-table__cell--numeric
-        = @submission.order_count
-      %td.govuk-table__cell.govuk-table__cell--numeric
-        = number_to_currency(@submission.order_total_value, unit: '£')
-    %tr.govuk-table__row
+    %tr.govuk-table__row.invoices
       %th.govuk-table__header{ scope: 'row' }
         Invoices
       %td.govuk-table__cell.govuk-table__cell--numeric
         = submission.invoice_count
       %td.govuk-table__cell.govuk-table__cell--numeric
         = number_to_currency(@submission.invoice_total_value, unit: '£')
+    %tr.govuk-table__row.contracts
+      %th.govuk-table__header{ scope: 'row' }
+        Contracts
+      %td.govuk-table__cell.govuk-table__cell--numeric
+        = @submission.order_count
+      %td.govuk-table__cell.govuk-table__cell--numeric
+        = number_to_currency(@submission.order_total_value, unit: '£')
+    %tr.govuk-table__row.others
+      %th.govuk-table__header{ scope: 'row' }
+        Others
+      %td.govuk-table__cell.govuk-table__cell--numeric
+        = submission.other_count
+      %td.govuk-table__cell.govuk-table__cell

--- a/spec/features/users_can_upload_completed_spreadsheet_spec.rb
+++ b/spec/features/users_can_upload_completed_spreadsheet_spec.rb
@@ -108,7 +108,7 @@ RSpec.feature 'User uploads completed spreadsheet' do
       expect(page).to have_content 'Please select a file'
     end
 
-    scenario 'see the current supplier name on the review view' do
+    scenario 'see the summary of a submission on the review page' do
       travel_to Time.zone.local(2018, 7, 2)
 
       mock_sso_with(email: 'email@example.com')
@@ -123,6 +123,18 @@ RSpec.feature 'User uploads completed spreadsheet' do
 
       expect(page).to have_content 'CBOARD5'
       expect(page).to have_content 'Bobs Cheese Shop'
+
+      within first('.contracts .govuk-table__cell') do
+        expect(page).to have_content '1'
+      end
+
+      within first('.invoices .govuk-table__cell') do
+        expect(page).to have_content '2'
+      end
+
+      within first('.others .govuk-table__cell') do
+        expect(page).to have_content '0'
+      end
     end
 
     scenario 'see the current supplier name on the complete view' do

--- a/spec/fixtures/mocks/completed_task.json
+++ b/spec/fixtures/mocks/completed_task.json
@@ -49,6 +49,7 @@
         "purchase_order_number": "PO123",
         "invoice_count": 42,
         "order_count": 99,
+        "other_count": 0,
         "invoice_total_value": 12345.67,
         "order_total_value": 987.65
       },

--- a/spec/fixtures/mocks/completed_task_with_no_business.json
+++ b/spec/fixtures/mocks/completed_task_with_no_business.json
@@ -48,7 +48,8 @@
         "submitted_at": "2019-02-14T15:39:38.151Z",
         "purchase_order_number": null,
         "invoice_count": 0,
-        "order_count": 0
+        "order_count": 0,
+        "other_count": 0
       },
       "relationships": {
         "files": {

--- a/spec/fixtures/mocks/correcting_task.json
+++ b/spec/fixtures/mocks/correcting_task.json
@@ -55,6 +55,7 @@
         "purchase_order_number": "PO123",
         "invoice_count": 42,
         "order_count": 99,
+        "other_count": 0,
         "invoice_total_value": 12345.67,
         "order_total_value": 987.65
       },
@@ -80,6 +81,7 @@
         "purchase_order_number": "PO123",
         "invoice_count": 42,
         "order_count": 99,
+        "other_count": 0,
         "invoice_total_value": 12345.67,
         "order_total_value": 987.65
       },

--- a/spec/fixtures/mocks/correcting_task_with_framework_and_active_submission.json
+++ b/spec/fixtures/mocks/correcting_task_with_framework_and_active_submission.json
@@ -49,6 +49,7 @@
         "purchase_order_number": "PO123",
         "invoice_count": 42,
         "order_count": 99,
+        "other_count": 0,
         "invoice_total_value": 12345.67,
         "order_total_value": 987.65
       },

--- a/spec/fixtures/mocks/submission_completed_no_business.json
+++ b/spec/fixtures/mocks/submission_completed_no_business.json
@@ -8,6 +8,7 @@
       "task_id": "2d98639e-5260-411f-a5ee-61847a2e067c",
       "invoice_count": 0,
       "order_count": 0,
+      "other_count": 0,
       "order_total_value": "0.0",
       "invoices_total_value": "0.0",
       "purchase_order_number": null,

--- a/spec/fixtures/mocks/submission_completed_report_mi.json
+++ b/spec/fixtures/mocks/submission_completed_report_mi.json
@@ -8,6 +8,7 @@
       "task_id": "2d98639e-5260-411f-a5ee-61847a2e067c",
       "invoice_count": 2,
       "order_count": 1,
+      "other_count": 0,
       "order_total_value": "1000.0",
       "invoices_total_value": "2000.0",
       "purchase_order_number": null,

--- a/spec/fixtures/mocks/submission_completed_with_task.json
+++ b/spec/fixtures/mocks/submission_completed_with_task.json
@@ -8,6 +8,7 @@
       "task_id": "2d98639e-5260-411f-a5ee-61847a2e067c",
       "invoice_count": 2,
       "order_count": 1,
+      "other_count": 0,
       "order_total_value": "1000.0",
       "invoices_total_value": "2000.0",
       "purchase_order_number": "PO123",

--- a/spec/fixtures/mocks/submission_errored.json
+++ b/spec/fixtures/mocks/submission_errored.json
@@ -15,6 +15,7 @@
       },
       "invoice_count": 2,
       "order_count": 1,
+      "other_count": 0,
       "order_total_value": "1000.0",
       "invoices_total_value": "2000.0",
       "purchase_order_number": null,

--- a/spec/fixtures/mocks/submission_management_charge_calculation_failed.json
+++ b/spec/fixtures/mocks/submission_management_charge_calculation_failed.json
@@ -15,6 +15,7 @@
       },
       "invoice_count": 2,
       "order_count": 1,
+      "other_count": 0,
       "order_total_value": "1000.0",
       "invoices_total_value": "2000.0",
       "purchase_order_number": null,

--- a/spec/fixtures/mocks/submission_pending.json
+++ b/spec/fixtures/mocks/submission_pending.json
@@ -8,6 +8,7 @@
       "task_id": "2d98639e-5260-411f-a5ee-61847a2e067c",
       "invoice_count": 0,
       "order_count": 0,
+      "other_count": 0,
       "order_total_value": "0.0",
       "invoices_total_value": "0.0",
       "purchase_order_number": null,

--- a/spec/fixtures/mocks/submission_validated.json
+++ b/spec/fixtures/mocks/submission_validated.json
@@ -8,6 +8,7 @@
       "task_id": "2d98639e-5260-411f-a5ee-61847a2e067c",
       "invoice_count": 2,
       "order_count": 1,
+      "other_count": 0,
       "order_total_value": "1000.00",
       "invoice_total_value": "2000.00",
       "purchase_order_number": "123",

--- a/spec/fixtures/mocks/submission_with_file.json
+++ b/spec/fixtures/mocks/submission_with_file.json
@@ -8,6 +8,7 @@
       "task_id": "2d98639e-5260-411f-a5ee-61847a2e067c",
       "invoice_count": 2,
       "order_count": 1,
+      "other_count": 0,
       "invoice_total_value": 123.45,
       "order_total_value": 42.42,
       "purchase_order_number": null,


### PR DESCRIPTION
Show users the count of submitted 'other' rows on the summary page.

## Screenshots of UI changes:

### Before

<img width="1056" alt="before" src="https://user-images.githubusercontent.com/3166/74449411-74255d00-4e74-11ea-9115-3e7ec2df4937.png">

### After

<img width="1060" alt="image" src="https://user-images.githubusercontent.com/3166/74449506-8e5f3b00-4e74-11ea-8be5-bac32a41c58b.png">
