### PR TITLE
(1115) Prevent users getting stuck after auth failure

### DIFF
--- a/app/views/errors/auth_failure.html.haml
+++ b/app/views/errors/auth_failure.html.haml
@@ -8,9 +8,8 @@
     %p
       We were unable to sign you in with the provided credentials. Please try again.
 
-    %p
-      %br
-      = link_to 'Sign in', '/auth/auth0', class: 'govuk-button govuk-button--start', id: 'sign-in', 'aria-label' => "Sign in to the service"
+    %p{class: 'govuk-!-margin-top-9'}
+      = button_to 'Sign in', '/auth/auth0', class: 'govuk-button govuk-button--start', id: 'sign-in', 'aria-label' => "Sign in to the service"
 
     %p
       If you are unable to sign in or do not receive a password reset email from the service contact

--- a/spec/features/users_can_sign_in_and_out_spec.rb
+++ b/spec/features/users_can_sign_in_and_out_spec.rb
@@ -17,10 +17,28 @@ RSpec.feature 'Signing in and out as a user' do
     mock_sso_failure(:invalid_credentials)
 
     visit '/tasks'
-
     click_on 'sign-in'
 
     expect(page).to have_content 'We were unable to sign you in with the provided credentials'
+  end
+
+  scenario 'Signing in unsuccessfully, but then retrying successfully' do
+    mock_sso_failure(:csrf_detected)
+
+    visit '/tasks'
+    click_on 'sign-in'
+
+    expect(page).to have_content 'We were unable to sign you in with the provided credentials'
+
+    # Allow Auth0 to succeed the second time
+    mock_sso_with(email: 'success@example.com')
+    mock_incomplete_tasks_endpoint!
+    mock_user_endpoint!
+
+    click_on 'sign-in'
+
+    expect(page).to have_content 'Tasks'
+    expect(page).to have_content 'Sign out'
   end
 
   scenario 'Signing out successfully' do


### PR DESCRIPTION
Change 'Sign in' button on the authentication failure page (/auth/failure/) to make a POST request, preventing users ending up on the 404 page.