### PR TITLE
(1196) Tidy up support pages, now we've replaced MISO

### DIFF
--- a/app/controllers/support_controller.rb
+++ b/app/controllers/support_controller.rb
@@ -3,8 +3,5 @@ class SupportController < ApplicationController
 
   def index; end
 
-  def frameworks
-    # API::Framework.all returns only published frameworks
-    @frameworks = API::Framework.all
-  end
+  def frameworks; end
 end

--- a/app/views/home/guest_homepage.html.haml
+++ b/app/views/home/guest_homepage.html.haml
@@ -14,7 +14,7 @@
       %li
         get the template for your framework(s)
       %li
-        report your management information to CCS for a selection of frameworks
+        report your management information to CCS
       %li
         report no business to CCS
     %p
@@ -31,22 +31,5 @@
 
     %p
       If you are not able to sign in or do not receive a password reset email, contact
-      = mail_to support_email_address
-      for help.
-
-    %h2.govuk-heading-m
-      Check which frameworks report here
-    %p
-      Check the
-      = link_to 'list of frameworks', '/support/frameworks'
-      that should be reported through this service.
-
-    %p
-      Use the
-      = link_to 'MISO service', 'https://miso.ccs.cabinetoffice.gov.uk/'
-      for all other commercial agreements.
-
-    %p
-      If you are unsure which service to use, you can email
       = mail_to support_email_address
       for help.

--- a/app/views/support/frameworks.html.haml
+++ b/app/views/support/frameworks.html.haml
@@ -1,29 +1,9 @@
 .govuk-grid-row
-  .govuk-grid-column-full
-    %h1.govuk-heading-xl
+  .govuk-grid-column-two-third
+    %h1.govuk-heading-l
       Check which service to report to
-.govuk-grid-row
-  .govuk-grid-column-two-thirds
-    %p
-      The following frameworks are submitted through this service.
-    %p
-      If you are reporting on any other framework, use the existing
-      = succeed '.' do
-        = link_to 'MISO service', 'https://miso.ccs.cabinetoffice.gov.uk/', :title => 'Link to MISO Service'
 
-.govuk-grid-row
-  .govuk-grid-column-full
-    = link_to('Back', '/',{ :class => 'govuk-back-link', :title => 'Link to start page'})
-    %table.govuk-table
-      %thead.govuk-table__head
-        %tr.govuk-table__row
-          %th.govuk-table__header{ :scope => 'col'}
-            Framework number
-          %th.govuk-table__header{ :scope => 'col'}
-            Framework name
-      %tbody.govuk-table__body
-        - @frameworks.each do |framework|
-          %tr.govuk-table__row
-            %td.govuk-table__cell= framework.short_name
-            %td.govuk-table__cell= framework.name
+    %p
+      As of March 2020, all frameworks should be reported using this service.
+
     = link_to('Back', '/',{ :class => 'govuk-back-link', :title => 'Link to start page'})

--- a/spec/requests/home_spec.rb
+++ b/spec/requests/home_spec.rb
@@ -5,7 +5,6 @@ RSpec.describe 'the home page' do
     get root_path
 
     expect(response.body).to include 'If you’re having trouble signing in'
-    expect(response.body).to include 'Check which frameworks report here'
   end
 
   it 'links to the user’s task list when signed in' do

--- a/spec/requests/support_spec.rb
+++ b/spec/requests/support_spec.rb
@@ -10,19 +10,4 @@ RSpec.describe 'support-rooted pages' do
       expect(response.body).to include('report-mi@crowncommercial.gov.uk')
     end
   end
-
-  describe 'the frameworks list' do
-    before do
-      mock_frameworks_endpoint!
-    end
-
-    it 'displays frameworks from the API' do
-      get support_frameworks_path
-
-      expect(response.body).to include('FM1001')
-      expect(response.body).to include('G Cloud 1')
-      expect(response.body).to include('FM1002')
-      expect(response.body).to include('G Cloud 2')
-    end
-  end
 end


### PR DESCRIPTION
ReportMI now handles submissions for *all* frameworks, so we can remove both the link to MISO and the list of supported frameworks.