### PR TITLE
Fix/new task list status text

### DIFF
--- a/app/models/api/task.rb
+++ b/app/models/api/task.rb
@@ -12,7 +12,8 @@ module API
     end
 
     def errors?
-      %w[validation_failed ingest_failed management_charge_calculation_failed].include?(active_submission&.status)
+      error_statuses = %w[validation_failed ingest_failed management_charge_calculation_failed]
+      error_statuses.include?(active_submission&.status) || error_statuses.include?(latest_submission&.status)
     end
 
     def late?

--- a/app/views/tasks/_task.html.haml
+++ b/app/views/tasks/_task.html.haml
@@ -27,8 +27,8 @@
         %strong.govuk-tag.govuk-tag__notice Correction
 
     - if task.status == 'in_progress' || task.correcting?
-      %p
-        - if  task.active_submission.status == 'in_review'
+      %p.ccs-task-status-message
+        - if task.active_submission.status == 'in_review' || task.latest_submission.status == 'in_review'
           This submission has been validated. Please review and submit to CCS.
         - else
           - if task.errors?

--- a/spec/features/user_can_cancel_correction_spec.rb
+++ b/spec/features/user_can_cancel_correction_spec.rb
@@ -17,12 +17,13 @@ RSpec.feature 'Cancelling a correction submission' do
       click_button 'sign-in'
 
       mock_correcting_task_with_framework_endpoint!
-      click_link 'Cancel correction'
+      within '#task-b847e0f7-027e-4b95-afa2-3490b8d05a1d' do
+        click_link 'Cancel correction'
+      end
       mock_correcting_task_endpoint!
       mock_correction_cancellation = mock_correction_cancellation_endpoint!
       mock_correcting_task_with_framework_and_active_submission_endpoint!
       click_button 'Cancel correction'
-
       expect(mock_correction_cancellation).to have_been_requested
       expect(current_path).to eq(task_path('b847e0f7-027e-4b95-afa2-3490b8d05a1d'))
       expect(page).to have_content('You have successfully cancelled the correction.')

--- a/spec/fixtures/mocks/incomplete_tasks_with_framework_and_active_submission.json
+++ b/spec/fixtures/mocks/incomplete_tasks_with_framework_and_active_submission.json
@@ -266,6 +266,45 @@
           }
         }
       }
+    },
+    {
+      "id": "445d1dd2-d9b3-4432-8c17-b63e90e50bcd",
+      "type": "tasks",
+      "attributes": {
+        "status": "correcting",
+        "framework_id": "fbe9c2dd-ad80-4398-8c92-f50a6a47d92e",
+        "supplier_id": "533a1357-4faf-4ced-b759-3e6da0bc5f3e",
+        "supplier_name": "Bobs Cheese Shop",
+        "description": null,
+        "due_on": "2018-09-07",
+        "period_year": 2018,
+        "period_month": 8
+      },
+      "relationships": {
+        "active_submission": {
+          "data": {
+            "type": "submissions",
+            "id": "67e7a34f-5d4c-4946-b045-da77f4b651db"
+          }
+        },
+        "latest_submission": {
+          "data": {
+            "type": "submissions",
+            "id": "67e7a34f-5d4c-4946-b045-da77f4b651db"
+          }
+        },
+        "submissions": {
+          "meta": {
+            "included": false
+          }
+        },
+        "framework": {
+          "data": {
+            "type": "frameworks",
+            "id": "fbe9c2dd-ad80-4398-8c92-f50a6a47d92e"
+          }
+        }
+      }
     }
   ],
   "included": [

--- a/spec/requests/tasks_spec.rb
+++ b/spec/requests/tasks_spec.rb
@@ -67,11 +67,30 @@ RSpec.describe 'the tasks list' do
     it 'lists a task with an incomplete correction' do
       correcting_task_id = 'b847e0f7-027e-4b95-afa2-3490b8d05a1d'
       correcting_submission_id = '43dfbd10-1c17-4f3c-8665-be8c27762923'
+
+      assert_select "#task-#{correcting_task_id}" do
+        assert_select '.govuk-tag__notice', text: 'Correction'
+        assert_select '.govuk-tag.govuk-tag__failure', text: 'Errors'
+        assert_select 'a[href=?]',
+                      task_submission_path(task_id: correcting_task_id,
+                                           id: correcting_submission_id,
+                                           correction: true),
+                      text: 'View and correct errors'
+        assert_select 'p.ccs-task-status-message',
+                      text: 'There were errors with this submission. Please submit a corrected return.'
+      end
+    end
+
+    it 'lists a task with a complete correction that is ready to submit' do
+      correcting_task_id = '445d1dd2-d9b3-4432-8c17-b63e90e50bcd'
+      correcting_submission_id = '67e7a34f-5d4c-4946-b045-da77f4b651db'
       assert_select "#task-#{correcting_task_id}" do
         assert_select '.govuk-tag__notice', text: 'Correction'
         assert_select 'a[href=?]',
-                      task_submission_path(task_id: correcting_task_id, id: correcting_submission_id, correction: true),
-                      text: 'View and correct errors'
+                      task_submission_path(task_id: correcting_task_id, id: correcting_submission_id),
+                      text: 'Review and submit'
+        assert_select 'p.ccs-task-status-message',
+                      text: 'This submission has been validated. Please review and submit to CCS.'
       end
     end
   end


### PR DESCRIPTION
Once in product review the redesigned task list in #303 has a couple of issue when a submission is being corrected that this PR aims to fix:

- the 'errors' flag is not showing on corrections with errors
- the status text not reflecting the status of the submission

Both problems seem to stem from a correction being a `latest_submission` not the `active_submission` - both the`errors?` method and the view logic do not seem to take this in to account, but the logic that shows the right buttons does, which was the clue I used to find the solution.

I've added a task and submission to the fixtures file that is in the status required to test, this meant fixing a feature elsewhere to cope with the additional task in the task list.