### PR TITLE
Adjust refresh timer on processing view

### DIFF
--- a/app/views/submissions/processing.html.haml
+++ b/app/views/submissions/processing.html.haml
@@ -1,11 +1,11 @@
 - page_title "Checking file: Report management information for #{@task.reporting_period} on #{@task.framework.short_name}"
 
-= content_for(:head, tag.meta('http-equiv': 'refresh', content: 30))
+= content_for(:head, tag.meta('http-equiv': 'refresh', content: 10))
 
 .govuk-grid-row
   .govuk-grid-column-full
     = link_to 'Back', tasks_path, { class: 'govuk-back-link', title: 'Back to your tasks' }
-      
+
     %h1.govuk-heading-l
       Checking file…
 


### PR DESCRIPTION
At the request of the client who felt 30 seconds is too long.

This change was introduced as part of an accessibility audit, but the
length of time was not mentioned.