### PR TITLE
Fix local Docker development environment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -13,3 +13,7 @@ terraform.tfstate
 ./*.tfstate
 .terraform/
 .terraform.tfstate.lock.info
+
+# Large things that bloat the build context in development
+log
+tmp

--- a/docker-compose.env.sample
+++ b/docker-compose.env.sample
@@ -1,5 +1,5 @@
 SECRET_KEY_BASE=1e68bf00783c255cf545c4b2a4548f1d863019323c705b0d210416b1db4746a553ff364b282069c0de45dc6d5f449265539faa9a91e8d7f4effc6798143547d2
-DATABASE_URL=postgres://postgres@db:5432/DataSubmissionService_development?template=template0&pool=5&encoding=unicode
+DATABASE_URL=postgres://postgres:password@db:5432/DataSubmissionService_development?template=template0&pool=5&encoding=unicode
 API_ROOT=http://api:3000/
 GOOGLE_ANALYTICS_ID=
 RAILS_SERVE_STATIC_FILES=true

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -8,7 +8,7 @@ services:
         RAILS_ENV: "test"
     environment:
       RAILS_ENV: "test"
-      DATABASE_URL: "postgres://postgres@db-test:5432/DataSubmissionService_test?template=template0&pool=5&encoding=unicode"
+      DATABASE_URL: "postgres://postgres:password@db-test:5432/DataSubmissionService_test?template=template0&pool=5&encoding=unicode"
       API_ROOT: "https://ccs.api/"
     env_file:
       - docker-compose.env
@@ -31,6 +31,8 @@ services:
       - tests
     restart: on-failure
     container_name: data-submission-service_db-test
+    environment:
+      POSTGRES_PASSWORD: "password"
 
 networks:
   tests:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,6 +32,8 @@ services:
     container_name: "data-submission-service_db"
     networks:
       private:
+    environment:
+      POSTGRES_PASSWORD: "password"
 volumes:
   pg_data: {}
   node_modules:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
     volumes:
       - .:/srv/dss:cached
       - node_modules:/srv/dss/node_modules
-    command: bash -c "rm -f tmp/pids/server.pid && rails s"
+    command: bash -c "rm -f tmp/pids/server.pid && rails s -b 0.0.0.0 -p 3100"
     container_name: "data-submission-service_web"
     networks:
       private:


### PR DESCRIPTION
## Changes in this PR:

This fixes the local Docker development environment, which has been broken for a while. I can now successfully:

- run the server with `bin/dstart` and access it at `http://localhost:3100`
- run the tests with `bin/dtest-server` and `bin/dspec`

The changes are similar to https://github.com/dxw/DataSubmissionServiceAPI/pull/628.

## Updating your local environment

You'll need to update your local `docker-compose.env` with the new `DATABASE_URL` from `docker-compose.env.sample`.